### PR TITLE
Add Travis ci configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+language: cpp
+
+sudo: required
+dist: trusty
+
+matrix:
+  include:
+    - name: "Linux build g++7.3"
+      os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - mesa-common-dev
+            - libglu1-mesa-dev
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        - COMPILER_SPEC=linux-g++
+        - BOOST_VERSION=1_65_1
+      before_install:
+        - eval "${MATRIX_EVAL}"
+        - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20
+        - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 20
+        - sudo add-apt-repository ppa:beineri/opt-qt596-trusty -y
+        - sudo apt-get update -qq
+      install:
+        # Qt
+        - sudo apt-get install -qq qt59base qt59tools qt59webchannel qt59webengine qt59svg
+        - source /opt/qt59/bin/qt59-env.sh 
+
+        # Boost
+        - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_${BOOST_VERSION}.tar.gz
+        - mkdir boost
+        - tar --strip-components=1 -xf boost_${BOOST_VERSION}.tar.gz -C boost
+        - rm -f boost_${BOOST_VERSION}.tar.gz
+        - cd boost
+        - ./bootstrap.sh
+        - ./b2 --with-filesystem --with-system link=shared threading=multi toolset=gcc stage
+        - export BOOST_INCLUDE="${TRAVIS_BUILD_DIR}/boost"
+        - export BOOST_LIB="${TRAVIS_BUILD_DIR}/boost/stage/lib"
+        - cd ${TRAVIS_BUILD_DIR}
+
+        # python and its modules
+        - sudo python -m pip install tabulate
+
+before_script:
+  - mkdir build
+  - cd build
+  - qmake --version
+  - echo BOOST_INCLUDE ${BOOST_INCLUDE}
+  - echo BOOST_LIB ${BOOST_LIB}
+  - qmake "DISABLE_PYTHON=yes" ../liger.pro -r -spec ${COMPILER_SPEC} 
+
+script:
+  - make -s
+  - cd tests/bin
+  - chmod +x run_all_unit_tests_linux.sh
+  - ./run_all_unit_tests_linux.sh
+  - python failure_reporter.py .
+

--- a/src/libs/botan/botan.pro
+++ b/src/libs/botan/botan.pro
@@ -11,6 +11,8 @@ HEADERS += $$PWD/botan.h \
     botan_global.h
 
 CONFIG -= qt
+CONFIG += warn_off
+
 equals(USE_SYSTEM_BOTAN, 1) {
     DEFINES += USE_SYSTEM_BOTAN
     CONFIG += link_pkgconfig

--- a/src/libs/json/json.pro
+++ b/src/libs/json/json.pro
@@ -7,6 +7,7 @@ dll {
 }
 
 CONFIG -= qt
+CONFIG += warn_off
 
 HEADERS += \
     json.h \

--- a/src/libs/tigon/Representation/Functions/FannNetwork.h
+++ b/src/libs/tigon/Representation/Functions/FannNetwork.h
@@ -18,8 +18,10 @@
 #include <tigon/tigon_global.h>
 
 #define FANN_NO_DLL
+DISABLE_WARNINGS
 #include <fann/doublefann.h>
 #include <fann/fann_cpp.h>
+ENABLE_WARNINGS
 
 namespace Tigon {
 namespace Representation {

--- a/src/libs/tigon/Utils/Kriging.h
+++ b/src/libs/tigon/Utils/Kriging.h
@@ -17,8 +17,10 @@
 #define KRIGING_H
 #include <tigon/tigon_global.h>
 #include <tigon/tigonconstants.h>
-#include <eigen/Eigen>
 #include <tigon/Utils/KrigingVariogram.h>
+DISABLE_WARNINGS
+#include <eigen/Eigen>
+ENABLE_WARNINGS
 
 namespace Tigon {
 class KrigingVariogram;

--- a/src/libs/tigon/Utils/KrigingCascade.h
+++ b/src/libs/tigon/Utils/KrigingCascade.h
@@ -17,7 +17,10 @@
 #define KRIGINGCASCADE_H
 #include <tigon/tigon_global.h>
 #include <tigon/tigonconstants.h>
+DISABLE_WARNINGS
 #include <eigen/Eigen>
+ENABLE_WARNINGS
+
 
 namespace Tigon {
 class Kriging;

--- a/src/libs/tigon/Utils/MultiPolynomialRegression.cpp
+++ b/src/libs/tigon/Utils/MultiPolynomialRegression.cpp
@@ -18,7 +18,9 @@
 #include <tigon/tigonconstants.h>
 #include <tigon/ExceptionHandling/TException.h>
 
+DISABLE_WARNINGS
 #include <eigen/Core>
+ENABLE_WARNINGS
 
 using namespace Eigen;
 

--- a/src/libs/tigon/Utils/ObjectiveReduction.h
+++ b/src/libs/tigon/Utils/ObjectiveReduction.h
@@ -24,7 +24,9 @@
 #include <tigon/Utils/TigonUtils.h>
 #include <tigon/ExceptionHandling/TException.h>
 
+DISABLE_WARNINGS
 #include <eigen/Eigenvalues>
+ENABLE_WARNINGS
 
 using Tigon::Representation::ISet;
 using Tigon::Representation::IMappingSPtr;

--- a/src/libs/tigon/Utils/PolynomialRegression.cpp
+++ b/src/libs/tigon/Utils/PolynomialRegression.cpp
@@ -15,7 +15,10 @@
 ****************************************************************************/
 #include <tigon/Utils/PolynomialRegression.h>
 #include <tigon/tigonconstants.h>
+
+DISABLE_WARNINGS
 #include <eigen/Core>
+ENABLE_WARNINGS
 
 using namespace Eigen;
 

--- a/src/libs/tigon/Utils/RBFInterpolator.cpp
+++ b/src/libs/tigon/Utils/RBFInterpolator.cpp
@@ -15,7 +15,10 @@
 ****************************************************************************/
 #include <tigon/Utils/RBFInterpolator.h>
 #include <tigon/Utils/RBFBasis.h>
+
+DISABLE_WARNINGS
 #include <eigen/Eigen>
+ENABLE_WARNINGS
 
 namespace Tigon {
 

--- a/src/libs/tigon/Utils/ScalarisingSpaceUtils.cpp
+++ b/src/libs/tigon/Utils/ScalarisingSpaceUtils.cpp
@@ -31,11 +31,9 @@ double scalarisingSpace(const TVector<TVector<double > >& objectiveSet,
 
     TVector<double> normObj;
     TVector<double> cost(n);
-    double minCost = 0;
     double ret = 0;
     // Loop through all directions
     for(int nDir=0; nDir<refSet.size(); nDir++) {
-        minCost = Tigon::Highest;
         for (int i=0; i<n; i++) {
             // Normalise objective vectors according to ideal and anti-ideal vectors
             normObj = normaliseToUnitBox(objectiveSet[i], ideal, antiIdeal);
@@ -90,11 +88,9 @@ double scalarisingSpaceRobust(const TVector<TVector<double> >& objectiveSet,
 
     TVector<double> cost_real(n);
     TVector<double> cost_inferred(n);
-    double minCost = 0;
     double ret = 0;
     // Loop through all directions
     for(int nDir=0; nDir<refSet.size(); nDir++) {
-        minCost = Tigon::Highest;
         for (int i=0; i<n; i++) {
             cost_real[i] = weightedChebyshev(refSet[nDir], normObj[i]);
         }
@@ -166,11 +162,9 @@ double scalarisingSpaceRobust(const TVector<TVector<double> >& objectiveSet,
 
     TVector<double> cost_real(n);
     TVector<double> cost_inferred(n);
-    double minCost = 0;
     double ret = 0;
     // Loop through all directions
     for(int nDir=0; nDir<refSet.size(); nDir++) {
-        minCost = Tigon::Highest;
         for (int i=0; i<n; i++) {
             cost_real[i] = weightedChebyshev(refSet[nDir], normObj[i]);
         }
@@ -220,11 +214,9 @@ double scalarisingSpaceRandom(const TVector<TVector<TVector<double> > >& objecti
     int nSampSize = objectiveSet[0][0].size();
     double cost_real = 0;
     TVector<double> cost_inferred(n);
-    double minCost = 0;
     double ret = 0;
     // Loop through all directions
     for(int nDir=0; nDir<refSet.size(); nDir++) {
-        minCost = Tigon::Highest;
         // Loop through all solutions
         SampledDistribution samp;
         for (int i=0; i<n; i++) {            

--- a/src/libs/tigon/Utils/SphericalVariogram.h
+++ b/src/libs/tigon/Utils/SphericalVariogram.h
@@ -3,7 +3,11 @@
 #include <tigon/tigon_global.h>
 #include <tigon/tigonconstants.h>
 #include <tigon/Utils/KrigingVariogram.h>
+
+DISABLE_WARNINGS
 #include <eigen/Dense>
+ENABLE_WARNINGS
+
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/limits.hpp>
 

--- a/src/libs/tigon/tigon.pro
+++ b/src/libs/tigon/tigon.pro
@@ -29,6 +29,8 @@ unix {
     #QMAKE_CXXFLAGS += -Werror
     QMAKE_CXXFLAGS_DEBUG   += -O0
     QMAKE_CXXFLAGS_RELEASE += -O3
+    # Disable certain warnings for now
+    QMAKE_CXXFLAGS += -Wno-sign-compare -Wno-int-in-bool-context -Wno-ignored-attributes
 }
 
 PRECOMPILED_HEADER = $$PWD/tigon_pch.h

--- a/src/libs/tigon/tigon_global.h
+++ b/src/libs/tigon/tigon_global.h
@@ -29,9 +29,42 @@
 #  define TIGON_FUNCTION_EXPORT extern "C" BOOST_SYMBOL_EXPORT
 #endif
 
+/// Macro used to to disable the warnings from external library.
+#if defined _MSC_VER
+#define DISABLE_WARNINGS __pragma(warning(push)) \
+    __pragma(warning(disable: 4503)) \
+    __pragma(warning(disable: 4702)) \
+    __pragma(warning(disable: 4996)) \
+    __pragma(warning(disable: 4100)) \
+    __pragma(warning(disable: 4127)) \
+    __pragma(warning(disable: 4244)) \
+    __pragma(warning(disable: 4267)) \
+    __pragma(warning(disable: 4512)) \
+    __pragma(warning(disable: 4510)) \
+    __pragma(warning(disable: 4610))
+#define ENABLE_WARNINGS __pragma(warning(pop))
+#elif defined __GNUC__
+#define DISABLE_WARNINGS                                                       \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wall\"") \
+    _Pragma("GCC diagnostic ignored \"-Wextra\"")                              \
+    _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                   \
+    _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")                 \
+    _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")              \
+    _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")                 \
+    _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")                \
+    _Pragma("GCC diagnostic ignored \"-Wattributes\"")                         \
+    _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")
+#define ENABLE_WARNINGS _Pragma("GCC diagnostic push")
+#else
+#define DISABLE_WARNINGS
+#define ENABLE_WARNINGS
+#endif
+
 /// Type Defs
 #include <complex>
+DISABLE_WARNINGS
 #include <eigen/Eigen>
+ENABLE_WARNINGS
 #include <tigon/Core/TVector.h>
 #include <tigon/Core/TString.h>
 #include <tigon/Core/TMap.h>

--- a/src/libs/tigon/tigon_pch.h
+++ b/src/libs/tigon/tigon_pch.h
@@ -61,7 +61,4 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
-// eigen
-#include <eigen/Dense>
-
 #endif

--- a/src/libs/tinyxml2/tinyxml2.pro
+++ b/src/libs/tinyxml2/tinyxml2.pro
@@ -5,6 +5,7 @@ dll {
 }
 
 CONFIG -= qt
+CONFIG += warn_off
 
 HEADERS += \
     tinyxml2.h

--- a/src/plugins/qtigon/dialogs/qopprobformulationnodeform.cpp
+++ b/src/plugins/qtigon/dialogs/qopprobformulationnodeform.cpp
@@ -474,13 +474,11 @@ void QOpProbFormulationNodeForm::variableToParameter(const InputPrivateData &old
     TVector<bool> isExternal;
     TVector<ElementProperties> pPrpts = problem->pPrpts();
     counter = 0;
-    int idx = -1;
     for(int i=0; i<pPrpts.size(); i++) {
         if(pPrpts[i].ID() == id) {
             // Transfered from variable
             parameterVector.push_back(IElementSPtr(new IElement(data.value)));
             isExternal.push_back(data.isExternal());
-            idx = parameterVector.size() - 1;
         } else {
             // Parameter still parameter
             parameterVector.push_back(m_prob->parameterVector()[counter]);

--- a/src/plugins/qtigon/qtigon.pro
+++ b/src/plugins/qtigon/qtigon.pro
@@ -11,7 +11,7 @@ include(../../libs/boost.pri)
 include(../../ligerplugin.pri)
 
 linux-* {
-
+    QMAKE_CXXFLAGS += -Wno-sign-compare
 }
 
 macx {
@@ -19,7 +19,7 @@ macx {
 }
 
 win32 {
-
+    QMAKE_CXXFLAGS += -wd4267
 }
 
 SOURCES += \ 

--- a/src/plugins/visualisation/qviznode.cpp
+++ b/src/plugins/visualisation/qviznode.cpp
@@ -543,7 +543,6 @@ void QVizNode::selectIterationSet(int iterationNumber)
             while(!jarray.empty()){
                 JsonObject jObj = jarray.takeAt(0).toObject();
                 IMappingSPtr imap = IMappingSPtr(new IMapping(m_ipset->problem()));
-                bool jsonOK = fromJSonObj(imap, jObj);
                 tempSet->append(imap);
             }
             setSelectedSet(tempSet);

--- a/tests/auto/test_tigon/test_baseoperations/tst_baseoperations.cpp
+++ b/tests/auto/test_tigon/test_baseoperations/tst_baseoperations.cpp
@@ -21,10 +21,12 @@
 #include <iomanip>
 
 #include <tigon/Tigon.h>
-#include <eigen/bench/BenchTimer.h>
-
 #include <tigon/Core/TString.h>
 #include <tigon/Core/TObject.h>
+
+DISABLE_WARNINGS
+#include <eigen/bench/BenchTimer.h>
+ENABLE_WARNINGS
 
 #include <boost/random.hpp>
 #include <boost/random/normal_distribution.hpp>

--- a/tests/auto/test_tigon/test_pythonfunction/tst_pythonfunction.cpp
+++ b/tests/auto/test_tigon/test_pythonfunction/tst_pythonfunction.cpp
@@ -29,8 +29,8 @@ class tst_pythonfunction : public QObject
 public:
 
 private slots:
-    void initTestCase();
 #ifdef PYTHON_API
+    void initTestCase();
     void constructors();
     void definePath();
     void evaluate();
@@ -43,18 +43,14 @@ private slots:
 #endif
 };
 
+#ifdef PYTHON_API
 TString TestBinPath;
 
 void tst_pythonfunction::initTestCase()
 {
-#ifdef PYTHON_API
     TestBinPath = QCoreApplication::applicationDirPath().toStdString();
-#else
-    QEXPECT_FAIL("", "Python not found", Abort);
-#endif
 }
 
-#ifdef PYTHON_API
 void tst_pythonfunction::constructors()
 {
     PythonFunction pyfunc;

--- a/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
+++ b/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
@@ -21,10 +21,12 @@
 
 #include <tigon/Tigon.h>
 
+DISABLE_WARNINGS
 #include <eigen/Core>
-#include <boost/math/special_functions/factorials.hpp>
 #include <eigen/bench/BenchTimer.h>
+ENABLE_WARNINGS
 
+#include <boost/math/special_functions/factorials.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/lexical_cast.hpp>

--- a/tests/manual/manual_tigon/manual_matlabengine/manual_matlabengine.cpp
+++ b/tests/manual/manual_tigon/manual_matlabengine/manual_matlabengine.cpp
@@ -17,7 +17,10 @@
 #include <QDir>
 #include <iostream>
 #include <tigon/Tigon.h>
+
+DISABLE_WARNINGS
 #include <eigen/bench/BenchTimer.h>
+ENABLE_WARNINGS
 
 using namespace Tigon;
 using namespace Tigon::Representation;


### PR DESCRIPTION
## Summary

This commit adds the configuration file ```.travis.yml``` to trigger a CI build for each commit and pull request.  
For now, only one set of configuration is enabled:

```
Qt: 5.9.6
boost: 1.65.1 (to be consistent with windows config)
g++: version 7.3
```

Before we can use Travis CI, please follow the steps 1-3 [here](https://docs.travis-ci.com/user/getting-started/#to-get-started-with-travis-ci) to activate it. 

## Detail
* Add config file for Travis CI (Linux g++-7 only for now)
* Disable all warnings from eigen and fann
* Disable certain warnings in the code base

## Note
Disabled some warnings to reduce the verbose level. However, all warnings in the code base should be properly dealt with. Being able to enable warning-as-error is desirable.

## TODO
* Populate the config for macOS with clang compiler