### PR TITLE
Update to the Windows installation files

### DIFF
--- a/dev/WindowsBuild/LigerSetupBuilder.iss
+++ b/dev/WindowsBuild/LigerSetupBuilder.iss
@@ -2,9 +2,9 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 ;#define MyAppName "Liger"
-;#define MyAppVersion "0.6.0"
+;#define MyAppVersion "1.1.0"
 ;#define MyAppPublisher "The University of Sheffield"
-;#define MyAppURL "http://ligeropt.sourceforge.net/"
+;#define MyAppURL "https://github.com/ligerdev/liger"
 ;#define MyAppExeName "liger.exe"
 
 ;#define ProjectDir "C:\Users\steve\Documents\SmartGit_Repos\liger"
@@ -50,7 +50,7 @@ Source: "{#BuildDir}\bin\liger.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "{#BuildDir}\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#BuildDir}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#BuildDir}\share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#BuildDir}\bin\vcredist_x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "{#BuildDir}\bin\vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
@@ -60,7 +60,7 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"; Tas
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"; Tasks: quicklaunchicon
 
 [Run]
-Filename: "{tmp}\vcredist_x64.exe"; Check: VCRedistNeedsInstall; Flags: postinstall nowait skipifsilent
+Filename: "{tmp}\vc_redist.x64.exe"; Check: VCRedistNeedsInstall; Flags: postinstall nowait skipifsilent
 
 [Registry]
 Root: HKCR; Subkey: ".lgr"; ValueType: string; ValueName: ""; ValueData: "LigerWorkflowFile"; Flags: uninsdeletevalue

--- a/dev/WindowsBuild/buildLigerReleaseForInstaller.bat
+++ b/dev/WindowsBuild/buildLigerReleaseForInstaller.bat
@@ -17,11 +17,11 @@ REM SET BOOST_PYTHON_LIB=C:\Boost\lib\vc141
 
 REM SET PYTHON_DLL=C:\Windows\System32\python27.dll
 REM SET VCBATCHDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-REM SET COMPILER_DIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\bin\Hostx64\x64
+REM SET COMPILER_DIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\bin\Hostx64\x64
 REM Inputs For Inno Setup Builder
 REM SET INNO_SETUP_DIR=C:\Program Files (x86)\Inno Setup 5
 REM SET EXEC_NAME=liger.exe
-REM SET APPURL=http://ligeropt.sourceforge.net/
+REM SET APPURL=https://github.com/ligerdev/liger
 REM SET PUBLISHER=The University of Sheffield
 REM SET APPNAME=Liger
 REM =======================================================================
@@ -45,7 +45,7 @@ CD /D %BUILDDIR%
 qmake.exe "CONFIG+=NO_TESTS" "%LIGERSRC%\liger.pro" -r -spec win32-msvc
 CALL "%VCBATCHDIR%\vcvarsall.bat" amd64
 CD /D %BUILDDIR%
-jom.exe -j12
+jom.exe -j8
 
 RD  /S /Q "%BUILDDIR%\src"
 RD  /S /Q "%BUILDDIR%\tests"


### PR DESCRIPTION
In the LigerSetupBuilder.iss file:
Update to the Liger version
Change the website from sourceforge to github
Change from vcredist_x64.exe to vc_redist.x64.exe, since the former seems to be deprecated.

In the buildLigerReleaseForInstaller.bat
Update to the Liger version
The compiler directory corresponds to the new version of the redistributable, that is, 14.15.26726 as opposed to 14.12.25827