### PR TITLE
Fix preferability to allow objectives without goals being set

### DIFF
--- a/src/libs/tigon/Utils/DominanceUtils.cpp
+++ b/src/libs/tigon/Utils/DominanceUtils.cpp
@@ -696,16 +696,20 @@ tribool preferability(const TVector<double> &a,
     int bclass=0;
 
     for(int k=0; k<Nobj; k++) {
-        if(a[k]>g[k]) {
-            aclass=1;
-            break;
+        if(!areDoublesEqual(g[k],Tigon::Lowest)) { // only for set goals
+            if(a[k] > g[k]) {
+                aclass=1;
+                break;
+            }
         }
     }
 
     for(int k=0; k<Nobj; k++) {
-        if(b[k]>g[k]) {
-            bclass=1;
-            break;
+        if(!areDoublesEqual(g[k],Tigon::Lowest)) { // only for set goals
+            if(b[k] > g[k]) {
+                bclass=1;
+                break;
+            }
         }
     }
 
@@ -720,21 +724,23 @@ tribool preferability(const TVector<double> &a,
     AbetterB = AequalB = BbetterA = BequalA = 1;
 
     for(int k=0; k<Nobj; k++) {
-        if(a[k]>g[k]) {
-            if(weakDom) {
-                AbetterB *= (a[k] <= b[k]);
-            } else {
-                AbetterB *= (a[k] < b[k]);
+        if(!areDoublesEqual(g[k],Tigon::Lowest)) { // only for set goals
+            if(a[k] > g[k]) { // a does not meet the goal
+                if(weakDom) {
+                    AbetterB *= (a[k] <= b[k]);
+                } else {
+                    AbetterB *= (a[k] < b[k]);
+                }
+                AequalB  *= (a[k] == b[k]);
             }
-            AequalB  *= (a[k] == b[k]);
-        }
-        if(b[k]>g[k]) {
-            if(weakDom) {
-                BbetterA *= (b[k] <= a[k]);
-            } else {
-                BbetterA *= (b[k] < a[k]);
+            if(b[k] > g[k]) { // b does not meet the goal
+                if(weakDom) {
+                    BbetterA *= (b[k] <= a[k]);
+                } else {
+                    BbetterA *= (b[k] < a[k]);
+                }
+                BequalA  *= (b[k] == a[k]);
             }
-            BequalA  *= (b[k] == a[k]);
         }
     }
 

--- a/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
+++ b/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
@@ -1129,6 +1129,7 @@ void tst_tigonutilities::test_preferability()
 {
     /// solution a is preferred to b:
     /// solutions a and b do not meet the goal for the first objective
+    /// both solutions meet the goal for the second and third objective
     /// a dominates b with respect to the first objective
     TVector<double> a = {1.5,0.5,0.5};
     TVector<double> b = {2.0,0.5,0.5};
@@ -1161,7 +1162,7 @@ void tst_tigonutilities::test_preferability()
 
     /// solution a is equivalent to b:
     /// both solutions meet the goals
-    /// a does not dominate b (or vice-versa) with respect to any objective
+    /// a and b are non-dominated
     a = {0.5,0.5,0.4};
     b = {0.5,0.3,0.5};
     g = {1.0,1.0,1.0};
@@ -1173,12 +1174,38 @@ void tst_tigonutilities::test_preferability()
     /// solution a is equivalent to b:
     /// solution a does not meet the first objective goal, but solution b does
     /// solution b does not meet the second objective goal, but solution a does
+    /// a and b are non-dominated
     a = {1.1,0.9,0.9};
     b = {0.9,1.1,0.9};
     g = {1.0,1.0,1.0};
 
     res = preferability(a,b,g);
     TCOMPARE(res, incomparable);
+
+
+    /// solution a is preferred to b:
+    /// solution b does not meet the first objective goal, but solution a does
+    /// the goals for the second and third objectives have not been set
+    /// solution b is better than a in the second and third objective
+    a = {0.9,2.0,2.0};
+    b = {1.1,1.0,1.0};
+    g = {1.0, Tigon::Lowest, Tigon::Lowest};
+
+    res = preferability(a,b,g);
+    TCOMPARE(res, true);
+
+
+    /// solution a is preferred to b:
+    /// solution b does not meet the first and third objective goal,
+    ///  but solution a does
+    /// the goal for the second objective has not been set
+    /// solution b is better than a in the second objective
+    a = {0.9,2.0,1.0};
+    b = {1.1,1.0,2.0};
+    g = {1.0, Tigon::Lowest, 1.5};
+
+    res = preferability(a,b,g);
+    TCOMPARE(res, true);
 }
 
 void tst_tigonutilities::test_truncateIntoFeasibleDomain()


### PR DESCRIPTION
Previously when setting goals, it was required for the user to set goals for all objectives. With this fix, it is now possible to only set goals for a subset of objectives.

Two test have been added to Tigon utilities.