### PR TITLE
Add travis config for macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,32 @@
 language: cpp
 
 sudo: required
-dist: trusty
 
 matrix:
   include:
+    - name: "MacOS build apple clang 10.0.0"
+      os: osx
+      osx_image: xcode10
+      env:
+        - COMPILER_SPEC=macx-clang
+        - TEST_SCRIPT=run_all_unit_tests.sh
+      install:
+        # Qt5.10.1 
+        - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8d4d48f0bb552b7b107119aeef59f141ce1f72c3/Formula/qt.rb
+        - export PATH="/usr/local/opt/qt/bin:$PATH"
+        
+        # Boost 1.67.0_1
+        - brew install boost
+        - export BOOST_INCLUDE="/usr/local/Cellar/boost/1.67.0_1/include"
+        - export BOOST_LIB="/usr/local/Cellar/boost/1.67.0_1/lib"
+
+        # python and modules
+        - brew install python3
+        - python -m pip install tabulate 
+
     - name: "Linux build g++7.3"
       os: linux
+      dist: trusty
       addons:
         apt:
           sources:
@@ -18,7 +38,10 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
         - COMPILER_SPEC=linux-g++
-        - BOOST_VERSION=1_65_1
+        - BOOST_SRC=boost_1_65_1.tar.gz
+        - BOOST_URL=https://dl.bintray.com/boostorg/release/1.65.1/source
+        - BOOST_TOOLSET=gcc
+        - TEST_SCRIPT=run_all_unit_tests_linux.sh
       before_install:
         - eval "${MATRIX_EVAL}"
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20
@@ -31,21 +54,21 @@ matrix:
         - source /opt/qt59/bin/qt59-env.sh 
 
         # Boost
-        - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_${BOOST_VERSION}.tar.gz
+        - wget ${BOOST_URL}/${BOOST_SRC}
         - mkdir boost
-        - tar --strip-components=1 -xf boost_${BOOST_VERSION}.tar.gz -C boost
-        - rm -f boost_${BOOST_VERSION}.tar.gz
+        - tar --strip-components=1 -xf ${BOOST_SRC} -C boost
+        - rm -f ${BOOST_SRC}
         - cd boost
         - ./bootstrap.sh
-        - ./b2 --with-filesystem --with-system link=shared threading=multi toolset=gcc stage
+        - ./b2 --with-filesystem --with-system link=shared threading=multi toolset=${BOOST_TOOLSET} stage
         - export BOOST_INCLUDE="${TRAVIS_BUILD_DIR}/boost"
         - export BOOST_LIB="${TRAVIS_BUILD_DIR}/boost/stage/lib"
-        - cd ${TRAVIS_BUILD_DIR}
-
-        # python and its modules
-        - sudo python -m pip install tabulate
+        
+        # python modules
+        - sudo python -m pip install tabulate 
 
 before_script:
+  - cd ${TRAVIS_BUILD_DIR}
   - mkdir build
   - cd build
   - qmake --version
@@ -56,7 +79,7 @@ before_script:
 script:
   - make -s
   - cd tests/bin
-  - chmod +x run_all_unit_tests_linux.sh
-  - ./run_all_unit_tests_linux.sh
+  - chmod +x ${TEST_SCRIPT}
+  - ./${TEST_SCRIPT}
   - python failure_reporter.py .
 

--- a/src/libs/tigon/Operators/Fitness/Scalarization.h
+++ b/src/libs/tigon/Operators/Fitness/Scalarization.h
@@ -47,7 +47,6 @@ private:
     TString   m_name;
     TString   m_description;
 
-    int       m_refSetSize;
     TVector<double>             m_weight;
     Tigon::ScalarisationType m_scalarisingFunc;
     double                       m_pNorm;

--- a/src/libs/tigon/tigon.pro
+++ b/src/libs/tigon/tigon.pro
@@ -25,8 +25,14 @@ win32-msvc* {
     QMAKE_CXXFLAGS += -wd4251 -wd4267 -wd4275
 }
 
-unix {
-    #QMAKE_CXXFLAGS += -Werror
+macx-clang {
+    QMAKE_CXXFLAGS_DEBUG   += -O0
+    QMAKE_CXXFLAGS_RELEASE += -O3
+    # Disable certain warnings for now
+    QMAKE_CXXFLAGS += -Wno-sign-compare -Wno-ignored-attributes
+}
+
+linux-g++ {
     QMAKE_CXXFLAGS_DEBUG   += -O0
     QMAKE_CXXFLAGS_RELEASE += -O3
     # Disable certain warnings for now

--- a/src/libs/tigon/tigon_global.h
+++ b/src/libs/tigon/tigon_global.h
@@ -43,9 +43,16 @@
     __pragma(warning(disable: 4510)) \
     __pragma(warning(disable: 4610))
 #define ENABLE_WARNINGS __pragma(warning(pop))
+#elif defined __clang__
+#define DISABLE_WARNINGS                          \
+    _Pragma("clang diagnostic push")              \
+    _Pragma("clang diagnostic ignored \"-Wall\"") \
+    _Pragma("clang diagnostic ignored \"-Wextra\"")
+#define ENABLE_WARNINGS _Pragma("clang diagnostic pop")
 #elif defined __GNUC__
 #define DISABLE_WARNINGS                                                       \
-    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wall\"") \
+    _Pragma("GCC diagnostic push")                                             \
+    _Pragma("GCC diagnostic ignored \"-Wall\"")                                \
     _Pragma("GCC diagnostic ignored \"-Wextra\"")                              \
     _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                   \
     _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")                 \
@@ -54,7 +61,7 @@
     _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")                \
     _Pragma("GCC diagnostic ignored \"-Wattributes\"")                         \
     _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")
-#define ENABLE_WARNINGS _Pragma("GCC diagnostic push")
+#define ENABLE_WARNINGS _Pragma("GCC diagnostic pop")
 #else
 #define DISABLE_WARNINGS
 #define ENABLE_WARNINGS

--- a/tests/utilities/run_all_unit_tests.sh
+++ b/tests/utilities/run_all_unit_tests.sh
@@ -1,7 +1,7 @@
 rm test_*.log
 for FILE in `find . -name 'test_*' -type f`
 do
-    echo Start ${FILE}; ${FILE} > ${FILE}.log &
+    ${FILE} -silent -xunitxml -o ${FILE}.xml > ${FILE}.log &
 done
 
 while :
@@ -19,8 +19,7 @@ do
 done
 
 echo "Check results"
-for LOG in `find . -name 'test_*.log' -type f`
+for RES in `find . -name 'test_*.xml' -type f`
 do
-    echo ${LOG}
-    cat ${LOG} | tail -2 | head -1
+    cat ${RES} | head -2 | tail -1 | awk '{ print "<" $5 ": "  $3}'
 done


### PR DESCRIPTION
Enable CI on MacOS via Travis

Configurations:
- Qt5.10.1
- Boost 1.67.0_1
- Apple Clang 10 

Also 
- Update macros to disable warnings for clang compiler from 3rd-party libs
- Update scripts to execute unit tests on mac


