### PR TITLE
Fix to conversion between bool and tribool

### DIFF
--- a/src/libs/tigon/Utils/TigonUtils.cpp
+++ b/src/libs/tigon/Utils/TigonUtils.cpp
@@ -134,7 +134,7 @@ TVector <int> randomPermutationSampling(int nSamps)
 
 bool isGoalDefined(IElementSPtr goal)
 {
-    return (*goal > goal->minValue());
+    return bool(*goal > goal->minValue());
 }
 
 bool areDoublesEqual(double a, double b)
@@ -146,7 +146,7 @@ bool areDoublesEqual(double a, double b)
 
 bool isThresholdDefined(IElementSPtr threshold)
 {
-    return *threshold < threshold->maxValue();
+    return bool(*threshold < threshold->maxValue());
 }
 
 std::ostream &operator<<(std::ostream &os, ISet * const pop)


### PR DESCRIPTION
This is a fix in TigonUtils to force a conversation from tribool to bool. This issue arises after Qt 5.9.7.