### PR TITLE
Use building status badges from travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Liger
 
-[![build status](http://ligerdev.sheffield.ac.uk/liger-development-team/liger/badges/develop/build.svg)](http://ligerdev.sheffield.ac.uk/liger-development-team/liger/commits/master) 
-[![coverage report](http://ligerdev.sheffield.ac.uk/liger-development-team/liger/badges/develop/coverage.svg)](http://ligerdev.sheffield.ac.uk/liger-development-team/liger/commits/master)
+[![Build Status](https://travis-ci.com/ligerdev/liger.svg?branch=master)](https://travis-ci.com/ligerdev/liger)
 
 ## Introduction
 


### PR DESCRIPTION
* Replace the old building status badge from the internal build system with the one from travis
* Remove coverage status badge