### PR TITLE
Fix to Python and Boost paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
             - libqt5svg5
             - libqt5svg5-dev
             - libqt5help5
+            - libqt5xmlpatterns5
+            - libqt5xmlpatterns5-dev
             - qttools5-dev
             - qttools5-dev-tools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
             - libqt5webengine5
             - libqt5webchannel5
             - libqt5svg5
+            - libqt5svg5-dev
             - libqt5help5
             - qttools5-dev
             - qttools5-dev-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
             - libqt5xmlpatterns5-dev
             - qttools5-dev
             - qttools5-dev-tools
+            - qtxmlpatterns5-dev-tools
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
             - libqt5webengine-data
             - libqt5webenginewidgets5
             - libqt5webenginecore5
+            - qtwebengine5-dev
+            - qtwebengine5-private-dev
             - qtwebengine5-dev-tools
             - libqt5widgets5
             - libqt5webchannel5

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ matrix:
             - qt5-qmake
             - qtbase5-dev
             - libqt5webengine5
+            - libqt5webengine-data
             - libqt5webenginewidgets5
+            - libqt5webenginecore5
+            - qtwebengine5-dev-tools
             - libqt5webchannel5
             - libqt5webchannel5-dev
             - libqt5svg5

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
             - libqt5webchannel5
             - libqt5svg5
             - libqt5help5
+            - qttools5-dev
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ matrix:
             - qt5-qmake
             - qtbase5-dev
             - libqt5webengine5
+            - libqt5webenginewidgets5
             - libqt5webchannel5
+            - libqt5webchannel5-dev
             - libqt5svg5
             - libqt5svg5-dev
             - libqt5help5

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
             - libqt5webenginewidgets5
             - libqt5webenginecore5
             - qtwebengine5-dev-tools
+            - libqt5widgets5
             - libqt5webchannel5
             - libqt5webchannel5-dev
             - libqt5svg5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
             - g++-7
             - mesa-common-dev
             - libglu1-mesa-dev
+            - qt5-default
             - qt5-qmake
             - libqt5webengine5
             - libqt5webchannel5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ matrix:
             - libglu1-mesa-dev
             - qt5-default
             - qt5-qmake
+            - qtbase5-dev
             - libqt5webengine5
             - libqt5webchannel5
             - libqt5svg5
             - libqt5help5
             - qttools5-dev
+            - qttools5-dev-tools
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
@@ -62,6 +64,7 @@ before_script:
   - cd build
   - qmake --version
   - python --version
+  - export QT_SELECT=qt5
   - echo BOOST_INCLUDE ${BOOST_INCLUDE}
   - echo BOOST_LIB ${BOOST_LIB}
   - qmake "DISABLE_PYTHON=yes" ../liger.pro -r -spec ${COMPILER_SPEC} 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
             - libqt5webengine5
             - libqt5webchannel5
             - libqt5svg5
+            - libqt5help5
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"

--- a/.travis.yml_old
+++ b/.travis.yml_old
@@ -6,7 +6,7 @@ matrix:
   include:
     - name: "Linux build g++7.3"
       os: linux
-      dist: bionic
+      dist: trusty
       addons:
         apt:
           sources:
@@ -15,11 +15,6 @@ matrix:
             - g++-7
             - mesa-common-dev
             - libglu1-mesa-dev
-            - qt5-qmake
-            - libqt5webengine5
-            - libqt5webchannel5
-            - libqt5svg5
-
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
         - COMPILER_SPEC=linux-g++
@@ -31,13 +26,12 @@ matrix:
         - eval "${MATRIX_EVAL}"
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20
         - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 20
-          #- sudo add-apt-repository ppa:beineri/opt-qt596-trusty -y
-          #- sudo apt-get update -qq
+        - sudo add-apt-repository ppa:beineri/opt-qt596-trusty -y
+        - sudo apt-get update -qq
       install:
         # Qt
-        #- sudo apt-get install -qq qt5-qmake libqt5webengine5 libqt5webchannel5 libqt5svg5 
-        #- sudo apt-get install -qq qt59base qt59tools qt59webchannel qt59webengine qt59svg qt5-qmake
-        #- source /opt/qt59/bin/qt59-env.sh 
+        - sudo apt-get install -qq qt59base qt59tools qt59webchannel qt59webengine qt59svg
+        - source /opt/qt59/bin/qt59-env.sh 
 
         # Boost
         - wget ${BOOST_URL}/${BOOST_SRC}

--- a/src/libs/tigon/tigon.pro
+++ b/src/libs/tigon/tigon.pro
@@ -532,7 +532,15 @@ contains(HAVE_PYTHON, yes) {
       LIBS += $$(BOOST_PYTHON_LIB)/libboost_python-mt.dylib
   }
   linux-* {
-      LIBS += $$(BOOST_PYTHON_LIB)/libboost_python.so
+      exists($$(BOOST_PYTHON_LIB)/libboost_python.so){
+          LIBS += $$(BOOST_PYTHON_LIB)/libboost_python.so
+      } else : exists($$(BOOST_PYTHON_LIB)/libboost_python27.so){
+          LIBS += $$(BOOST_PYTHON_LIB)/libboost_python27.so
+      } else {
+      message("The Boost python library has not been found.$$escape_expand(\\n) \
+          $$escape_expand(\\t)Check that BOOST_PYTHON_LIB is correctly set in the Project environemt variables.$$escape_expand(\\n) \
+          $$escape_expand(\\t)Check that the files libboost_python.so or libboost_python27.so exist in $$BOOST_PYTHON_LIB folder")
+      }
   }
 }
 
@@ -559,16 +567,30 @@ win32 {
 
     exists($$(BOOST_LIB)/boost_filesystem-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*){
         BOOST_DLLs = $$(BOOST_LIB)/boost_filesystem-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_* \
-                     $$(BOOST_LIB)/boost_system-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_* \
-                     $$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*
+                 $$(BOOST_LIB)/boost_system-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*
     } else : exists($$(BOOST_LIB)/boost_filesystem-vc???-mt-1_*) {
         BOOST_DLLs = $$(BOOST_LIB)/boost_filesystem-vc???-mt-$$BOOST_DEBUG_FLAG1_* \
-                     $$(BOOST_LIB)/boost_system-vc???-mt-$$BOOST_DEBUG_FLAG1_* \
-                     $$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG1_*
+                 $$(BOOST_LIB)/boost_system-vc???-mt-$$BOOST_DEBUG_FLAG1_*
     } else {
         message("The Boost libraries were not found.$$escape_expand(\\n) \
-                $$escape_expand(\\t)Check that BOOST_INCLUDE, BOOST_LIB and BOOST_PYTHON_LIB are correctly set in the Project environemt variables.$$escape_expand(\\n) \
-                $$escape_expand(\\t)Check that the files boost*vc???-mt-BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_* exist in $$BOOST_LIB folder")
+            $$escape_expand(\\t)Check that BOOST_INCLUDE, BOOST_LIB and BOOST_PYTHON_LIB are correctly set in the Project environemt variables.$$escape_expand(\\n) \
+            $$escape_expand(\\t)Check that the files boost*vc???-mt-BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_* exist in $$BOOST_LIB folder")
     }
+
+    # Add boost python library
+    exists($$(BOOST_LIB)/boost_python27-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*){
+        BOOST_DLLs += $$(BOOST_LIB)/boost_python27-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*
+    } else : exists($$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*){
+        BOOST_DLLs += $$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_*
+    } else : exists($$(BOOST_LIB)/boost_python27-vc???-mt-$$BOOST_DEBUG_FLAG1_*){
+        BOOST_DLLs += $$(BOOST_LIB)/boost_python27-vc???-mt-$$BOOST_DEBUG_FLAG1_*
+    } else : exists($$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG1_*){
+        BOOST_DLLs += $$(BOOST_LIB)/boost_python-vc???-mt-$$BOOST_DEBUG_FLAG1_*
+    } else {
+        message("The Boost libraries were not found.$$escape_expand(\\n) \
+            $$escape_expand(\\t)Check that BOOST_INCLUDE, BOOST_LIB and BOOST_PYTHON_LIB are correctly set in the Project environemt variables.$$escape_expand(\\n) \
+            $$escape_expand(\\t)Check that the files boost*vc???-mt-BOOST_DEBUG_FLAG$$BOOST_LIB_ARCH-1_* exist in $$BOOST_LIB folder")
+    }
+
     copyToDir($$BOOST_DLLs, $$LIGER_BIN_PATH/)
 }

--- a/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
+++ b/tests/auto/test_tigon/test_tigonutilities/tst_tigonutilities.cpp
@@ -26,11 +26,14 @@ DISABLE_WARNINGS
 #include <eigen/bench/BenchTimer.h>
 ENABLE_WARNINGS
 
-#include <boost/math/special_functions/factorials.hpp>
+// The Q_MOC_RUN prepocessor symbol tells the moc not to parse the following
+// headers, which seems to create problems to the moc.
+#ifndef Q_MOC_RUN
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#endif
 
 #include "multipolyregressiondata.h"
 


### PR DESCRIPTION
* Fix to Python and Boost paths for both Linux and Windows. Any version of boost higher than 1.66 can now be used for Windows.
* Fix to tigon utilities to avoid some compilation issues with more recent compilers where some headers are no longer parsed by the moc file.
* Update to travis script. Moved to bionic Ubuntu distro.