### PR TITLE
New Matlab C++ API

### DIFF
--- a/matlabcheck.pri
+++ b/matlabcheck.pri
@@ -1,20 +1,50 @@
 # Check if Matlab exists, if so set MATLAB_ROOT_PATH
-!contains(CONFIG, NO_MATLAB) {
-linux-* {
-#  TMP = $$system(whereis matlab)
-#  MATLABEXE = $$split(TMP," ")
-#  MATLABEXE = $$member(MATLABEXE, 1)
-# !isEmpty(MATLABEXE) {
-#    MATLAB_ROOT_PATH = $$system(readlink $$MATLABEXE)
-#    MATLAB_ROOT_PATH = $$replace(MATLAB_ROOT_PATH, "/bin/matlab","")
 
-#    !isEmpty(MATLAB_ROOT_PATH) {
-#      MATLAB_INCLUDE_PATH = $${MATLAB_ROOT_PATH}/extern/include
-#      MATLAB_LIB_PATH     = $${MATLAB_ROOT_PATH}/bin/glnxa64
-#      DEFINES += MATLAB_API
-#    }
-#  }
-}
+!contains(CONFIG, NO_MATLAB) {
+
+linux-* {
+
+  MATLAB_VERSIONS += "R2017b"
+  MATLAB_VERSIONS += "R2018a"
+  MATLAB_VERSIONS += "R2018b"
+  MATLAB_VERSIONS += "R2019a"
+  MATLAB_VERSIONS += "R2019b"
+  MATLAB_VERSIONS += "R2020a"
+  MATLAB_VERSIONS += "R2020b"
+
+  TMP = $$system(whereis matlab)
+  MATLABEXE = $$split(TMP," ")
+  MATLABEXE = $$member(MATLABEXE, 1)
+
+  !isEmpty(MATLABEXE) {
+    MATLAB_ROOT_PATH_TMP = $$system(readlink $$MATLABEXE)
+    MATLAB_ROOT_PATH_TMP = $$replace(MATLAB_ROOT_PATH_TMP, "/bin/matlab","")
+
+    # check if the matlab version is supported
+    MATLAB_SUPPORTED = 0
+    M_VERSION = ""
+    for(MATLAB_VERSION, MATLAB_VERSIONS) {
+      if(contains(MATLAB_ROOT_PATH_TMP, .*$${MATLAB_VERSION}.*)) {
+        MATLAB_SUPPORTED = 1
+        M_VERSION = $$MATLAB_VERSION
+      }
+    }
+
+    #message($$MATLAB_ROOT_PATH_TMP)
+
+    isEqual(MATLAB_SUPPORTED, 1) {
+      !isEmpty(MATLAB_ROOT_PATH_TMP) {
+        MATLAB_ROOT_PATH = $$MATLAB_ROOT_PATH_TMP
+        MATLAB_INCLUDE_PATH = $${MATLAB_ROOT_PATH}/extern/include
+        MATLAB_LIB_PATH     = $${MATLAB_ROOT_PATH}/extern/bin/glnxa64
+        DEFINES += MATLAB_API_CPP
+        DEFINES += MATLAB_API
+      }
+    }
+
+  } # end of isEmpty(MATLABEXE) {
+} # end of linux
+
 
 macx {
   MATLAB_PATHS += /Applications/MATLAB_R2013a.app
@@ -43,31 +73,108 @@ macx {
 }
 
 win32 {
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2013b"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2014a"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2014b"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2015a"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2015b"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2016a"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2016b"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2017a"
-  MATLAB_PATHS += "C:/Program Files/MATLAB/R2017b"
 
-  for(CURPATH, MATLAB_PATHS) {
-    if(exists($$CURPATH)) {
-      MATLAB_ROOT_PATH    = $$CURPATH
+  # The Matlab version used by Liger is chosen from the following two lists, and
+  # the criterion is to select the highest version number that is installed.
+  # Both C and C++ APIs work with Matlab version R2017b, but it is currently
+  # omitted from the C API to prevent any conflicts with the other API.
+
+  # The following list contains the Matlab versions that are compatible with
+  # the Matlab C API of Tigon.
+
+  MATLAB_VERSIONS_C += "R2013b"
+  MATLAB_VERSIONS_C += "R2014a"
+  MATLAB_VERSIONS_C += "R2014b"
+  MATLAB_VERSIONS_C += "R2015a"
+  MATLAB_VERSIONS_C += "R2015b"
+  MATLAB_VERSIONS_C += "R2016a"
+  MATLAB_VERSIONS_C += "R2016b"
+  MATLAB_VERSIONS_C += "R2017a"
+#  MATLAB_VERSIONS_C += "R2017b"
+
+  # The following list contains the Matlab versions that are compatible with
+  # the Matlab C++ API of Tigon.
+
+  MATLAB_VERSIONS_CPP += "R2017b"
+  MATLAB_VERSIONS_CPP += "R2018a"
+  MATLAB_VERSIONS_CPP += "R2018b"
+  MATLAB_VERSIONS_CPP += "R2019a"
+  MATLAB_VERSIONS_CPP += "R2019b"
+  MATLAB_VERSIONS_CPP += "R2020a"
+  MATLAB_VERSIONS_CPP += "R2020b"
+
+  # Use command WHERE to find where MATLAB is installed
+  # Use a silent call (/Q) that does not generate any output, just to check the error status
+  # This prevents qmake from displying "INFO: Could not find files for the given pattern(s)." in case Matlab does not exists
+  # The variable MATLAB_NOT_FOUND stores the error status, where 0 means OK (MATLAB found) and 1 means Error (MATLAB not found)
+  TT = $$system(WHERE /Q matlab, true, MATLAB_NOT_FOUND)
+
+  isEqual(MATLAB_NOT_FOUND, 0) { # if MATLAB has been found
+    TMP = $$system(WHERE /F matlab) # now retrieve the actual path(s) with brackets (/F)
+    MATLAB_LIST = $$split(TMP, "\" \"") # separate each MATLAB full path and return a list
+
+    # To manually select a MATLAB version in case more than one is installed,
+    # first uncomment the following three lines, then check the content of MATLAB_LIST.
+    # The 0 in the second line selects the first directory in MATLAB_LIST, and
+    # to select a different directory increase the number as appropriate.
+#    message($$MATLAB_LIST)
+#    MATLABTMP = $$member(MATLAB_LIST, 0)
+#    MATLAB_LIST = $$MATLABTMP
+
+    for(MATLABEXE, MATLAB_LIST) { # this loop goes through all paths that contains a matlab executable
+      if(contains(MATLABEXE, .*matlab.exe.*)) { # selects only those paths with matlab.exe
+         MATLABEXE = $$clean_path($$MATLABEXE) # replace \ by / (QT always uses / despite the OS)
+         #message($$MATLABEXE)
+
+         # check if the matlab version is supported by the C API
+         for(MATLAB_VERSION, MATLAB_VERSIONS_C) {
+           if(contains(MATLABEXE, .*$${MATLAB_VERSION}.*)) {
+             SELECTED_MATLAB = $$MATLABEXE
+             DEFINES *= MATLAB_API_C
+           }
+         }
+
+         # check if the matlab version is supported bu the C++ API
+         for(MATLAB_VERSION, MATLAB_VERSIONS_CPP) {
+           if(contains(MATLABEXE, .*$${MATLAB_VERSION}.*)) {
+             SELECTED_MATLAB = $$MATLABEXE
+             DEFINES *= MATLAB_API_CPP
+           } # if
+         } # for
+      } # if
+    } # for
+
+    contains(DEFINES, MATLAB_API_CPP) {
+      if(exists($$SELECTED_MATLAB)) { # check if the executable exists
+        SELECTED_MATLAB = $$replace(SELECTED_MATLAB, "\"","") # remove the character(")
+        MATLABEXE_PATH = $$dirname(SELECTED_MATLAB) # extract the directory
+        #message($$MATLABEXE)
+
+        MATLAB_ROOT_PATH = $$replace(MATLABEXE_PATH, "/bin","") # go back one directory
+        #message($$MATLAB_ROOT_PATH)
+      } # if executable exists
+    } # if matlab version is supported
+
+    contains(DEFINES, MATLAB_API_C) {
+      if(exists($$SELECTED_MATLAB)) { # check if the executable exists
+        SELECTED_MATLAB = $$replace(SELECTED_MATLAB, "\"","") # remove the character(")
+        MATLABEXE_PATH = $$dirname(SELECTED_MATLAB) # extract the directory
+        #message($$MATLABEXE)
+
+        MATLAB_ROOT_PATH = $$replace(MATLABEXE_PATH, "/bin","") # go back one directory
+        #message($$MATLAB_ROOT_PATH)
+      } # if executable exists
+    } # if matlab version is supported
+
+    !isEmpty(MATLAB_ROOT_PATH) {
       MATLAB_INCLUDE_PATH = $${MATLAB_ROOT_PATH}/extern/include
-      MATLAB_LIB_PATHA    = $${MATLAB_ROOT_PATH}/bin/win32
       MATLAB_LIB_PATHB    = $${MATLAB_ROOT_PATH}/extern/lib/win64/microsoft
-
       export(MATLAB_ROOT_PATH)
       export(MATLAB_INCLUDE_PATH)
-      export(MATLAB_LIB_PATHA)
       export(MATLAB_LIB_PATHB)
-    }
-  }
-  !isEmpty(MATLAB_ROOT_PATH) {
-    DEFINES += MATLAB_API
-  }
+      DEFINES += MATLAB_API
+    } # isEmpty
+
+  } # isEqual MATLAB_FOUND
 }
 }

--- a/src/app/app_version.h.in
+++ b/src/app/app_version.h.in
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2019 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/libs/matlabplugin/Representation/Functions/Matlab/MatlabFunction.h
+++ b/src/libs/matlabplugin/Representation/Functions/Matlab/MatlabFunction.h
@@ -22,7 +22,7 @@
 #include <tigon/Representation/Elements/IElement.h>
 
 namespace Tigon {
-class MatlabEngine;
+class IMatlabEngine;
 
 namespace Representation {
 

--- a/src/libs/matlabplugin/Utils/IMatlabEngine.cpp
+++ b/src/libs/matlabplugin/Utils/IMatlabEngine.cpp
@@ -2,6 +2,7 @@
 **
 ** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
+**
 ** This file is part of Liger.
 **
 ** GNU Lesser General Public License Usage
@@ -13,19 +14,43 @@
 ** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
 ****************************************************************************/
-#ifndef QOPERATORDIAGTABITEM_H
-#define QOPERATORDIAGTABITEM_H
+#include <matlabplugin/Utils/IMatlabEngine.h>
 
-#include <QWidget>
+namespace Tigon {
 
-class QOperatorDiagTabItem : public QWidget
+IMatlabEngine::IMatlabEngine()
 {
-    Q_OBJECT
 
-public:
-    explicit QOperatorDiagTabItem(QWidget *parent = 0);
-    virtual void reset() = 0;
-    virtual void save()  = 0;
-};
+}
 
-#endif // QOPERATORDIAGTABITEM_H
+IMatlabEngine::~IMatlabEngine()
+{
+
+}
+
+void IMatlabEngine::setErrorMessage(TString msg)
+{
+    m_errorBuff = msg;
+}
+
+TString IMatlabEngine::errorMessage()
+{
+    return m_errorBuff;
+}
+
+TStringList IMatlabEngine::commandHistory()
+{
+    return m_commandHist;
+}
+
+void IMatlabEngine::addCommand(TString cmd)
+{
+    m_commandHist.push_back(cmd);
+}
+
+void IMatlabEngine::clearCommandHistory()
+{
+    m_commandHist.clear();
+}
+
+} //namespace Tigon

--- a/src/libs/matlabplugin/Utils/IMatlabEngine.h
+++ b/src/libs/matlabplugin/Utils/IMatlabEngine.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
+**
+**
+** This file is part of Liger.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+****************************************************************************/
+#ifndef IMATLABENGINE_H
+#define IMATLABENGINE_H
+
+#include <tigon/tigon_global.h>
+#include <tigon/tigonconstants.h>
+
+namespace Tigon {
+
+class LIGER_TIGON_EXPORT IMatlabEngine
+{
+    friend class MatlabPool;
+
+public:
+    IMatlabEngine();
+    virtual ~IMatlabEngine();
+
+    TString errorMessage();
+    void setErrorMessage(TString msg);
+
+    TStringList commandHistory();
+    void addCommand(TString cmd);
+    void clearCommandHistory();
+
+
+    // Purely virtual methods
+    virtual bool evaluateString(const TString& command, bool errorCatch = true) = 0;
+    virtual void resetEngine() = 0;
+
+    virtual void setInteractive(bool visible) = 0;
+    virtual bool Interactive() = 0;
+
+    virtual void placeVariable(const TString &name, int value) = 0;
+    virtual void placeVariable(const TString &name, double value) = 0;
+    virtual void placeVariable(const TString &name, bool value) = 0;
+    virtual void placeVariable(const TString &name, TComplex value) = 0;
+    virtual void placeVariable(const TString &name, TString value) = 0;
+
+    // Place a vector into the MATLAB workspace, can be a row or column vector.
+    virtual void placeVectorColumn(const TString &name, const TVector<int>& vec) = 0;
+    virtual void placeVectorColumn(const TString &name, const TVector<double>& vec) = 0;
+    virtual void placeVectorColumn(const TString &name, const TVector<bool>& vec) = 0;
+    virtual void placeVectorColumn(const TString &name, const TVector<TComplex>& vec) = 0;
+
+    virtual void placeVectorRow(const TString &name, const TVector<int>& vec) = 0;
+    virtual void placeVectorRow(const TString &name, const TVector<double>& vec) = 0;
+    virtual void placeVectorRow(const TString &name, const TVector<bool>& vec) = 0;
+    virtual void placeVectorRow(const TString &name, const TVector<TComplex>& vec) = 0;
+
+    // Place a Matrix onto the MATLAB workspace
+    virtual void placeMatrix(const TString &name, const TVector<TVector<int>>& mat) = 0;
+    virtual void placeMatrix(const TString &name, const TVector<TVector<double>>& mat) = 0;
+    virtual void placeMatrix(const TString &name, const TVector<TVector<bool>>& mat) = 0;
+    virtual void placeMatrix(const TString &name, const TVector< TVector<TComplex>>& mat) = 0;
+
+    // Get Variable overides
+    virtual bool getWorkspaceVariable(const TString &name, int& value) = 0;
+    virtual bool getWorkspaceVariable(const TString &name, double& value) = 0;
+    virtual bool getWorkspaceVariable(const TString &name, bool& value) = 0;
+    virtual bool getWorkspaceVariable(const TString &name, TComplex& value) = 0;
+    virtual bool getWorkspaceVariable(const TString &name, TString& value) = 0;
+
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<int>& vec) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<double>& vec) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<bool>& vec) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<TComplex>& vec) = 0;
+
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<int>>& mat) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<double>>& mat) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<bool>>& mat) = 0;
+    virtual TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<TComplex> >& mat) = 0;
+
+private:
+    virtual void openEngine() = 0;
+    virtual void closeEngine() = 0;
+
+    TString m_errorBuff;
+    TStringList m_commandHist;
+};
+
+} // Tigon
+
+#endif // IMATLABENGINE_H

--- a/src/libs/matlabplugin/Utils/MatlabEngineX.cpp
+++ b/src/libs/matlabplugin/Utils/MatlabEngineX.cpp
@@ -1,0 +1,558 @@
+/****************************************************************************
+**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
+**
+** This file is part of Liger.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+****************************************************************************/
+#include <matlabplugin/Utils/MatlabEngineX.h>
+
+namespace Tigon {
+/*!
+ *\brief Create a MatlabEngine object.
+ *
+ * This constructor is private, only MatlabPool is allowed to create new MatlabEngine.
+ * Lazy initialization is used so the MATLAB engine is not started until a command
+ * is run or a variable placed.
+ */
+MatlabEngineX::MatlabEngineX()
+    : m_engine(nullptr)
+{
+
+}
+
+/*!
+ * \brief Destructor
+ *
+ * Destroys the MatlabEngine object and closes the MATLAB engine, stopping the MATLAB process.
+ */
+MatlabEngineX::~MatlabEngineX()
+{
+    closeEngine();
+}
+
+/*!
+ * \brief Starts the MATLAB engine
+ *
+ * Starts the MATLAB process and sets m_engine to point to the MATLAB engine.
+ *
+ * This operation is called once when an instance of MATLAB is first required,
+ * each MatlabEngine holds a reference to a MATLAB engine which runs until the
+ * MatlabEngine object is destroyed.
+ */
+void MatlabEngineX::openEngine()
+{
+    if(!m_engine) {
+        m_engine = startMATLAB();
+    }
+}
+
+/*!
+ * \brief Stop the MATLAB engine
+ *
+ * Stops the MATLAB process, closing the engine.
+ */
+void MatlabEngineX::closeEngine()
+{
+    if(m_engine) {
+        m_engine.release();
+        clearCommandHistory();
+    }
+}
+
+/*!
+ * \brief Resets the engine to an initial state.
+ *
+ * This clears the MATLAB workspace and the list of commands so far issued to
+ * the engine. Primarily used by MatlabPool to ensure the pooled engines are in
+ * a known initial state.
+ */
+void MatlabEngineX::resetEngine()
+{
+    if(m_engine) {
+        ///\note "clear all" was used to reset the engine. However, it sometimes
+        /// causes crash of Simulink. Changed to clearvars for now.
+        //evaluateString("clear all", 0);
+        evaluateString("clearvars", false);
+
+        clearCommandHistory();
+    }
+}
+
+/*!
+ * \brief Evaluate a string of commands in MATLAB
+ *
+ * Evaluate a string of commands in the MATLAB engine.
+ * \param command The string to be evaluated by MATLAB
+ * \param errorCatch Indicates if errors are to be logged (true) or not (false)
+ * \return True if evaluation succeeded, false if an error was thrown
+ */
+bool MatlabEngineX::evaluateString(const TString &command, bool errorCatch)
+{
+    if(!m_engine){
+        openEngine();
+    }
+
+    auto outBuf = std::make_shared<SBuf>();
+    auto errBuf = std::make_shared<SBuf>();
+
+    addCommand(command);
+
+    try {
+        m_engine->eval(convertUTF8StringToUTF16String(command), outBuf, errBuf);
+    } catch (const MATLABExecutionException& e) {
+        setErrorMessage(TString(e.what()));
+        return false;
+    }
+
+    bool error = false;
+    if(errorCatch) {
+        auto text_ = errBuf->str();
+        setErrorMessage(TString(convertUTF16StringToUTF8String(text_)));
+
+        if(errorMessage().length() > 0) {
+            error = true;
+        }
+    }
+
+    return !error;
+}
+
+/*!
+ * \brief Calls a function in Matlab and retrieves the output,
+ *
+ * Uses feval from the Matlab API.
+ *
+ * This is a good alternative to evaluateString to evaluate the problem model,
+ * since the inputs can have different types. The current implementation doesn't
+ * make use of this (useful) feature since all inputs are treated as doubles.
+ * \todo replace "const TVector<double>& in" by "const TVector<IElementSPrt>& in".
+ *
+ * \param funcName
+ * \param nOutputs
+ * \param in
+ * \param errorCatch
+ * \return
+ */
+TVector<double> MatlabEngineX::evaluateFunction(const TString& funcName,
+                                                const size_t nOutputs,
+                                                const TVector<double>& in,
+                                                bool errorCatch)
+{
+    if(!m_engine){
+        openEngine();
+    }
+
+    ArrayFactory factory;
+    TVector<Array> args;
+    args.reserve(in.size());
+    for(auto elem : in) {
+        args.push_back(factory.createScalar<double>(elem));
+    }
+
+    auto outBuf = std::make_shared<SBuf>();
+    auto errBuf = std::make_shared<SBuf>();
+
+    addCommand(funcName);
+
+    TVector<Array> rest;
+    try {
+        auto name = convertUTF8StringToUTF16String(funcName);
+        rest = m_engine->feval(name, nOutputs, args, outBuf, errBuf);
+    } catch (const MATLABExecutionException& e) {
+        setErrorMessage(TString(e.what()));
+        return TVector<double>(nOutputs);
+    }
+
+    if(errorCatch) {
+        auto text_ = errBuf->str();
+        setErrorMessage(TString(convertUTF16StringToUTF8String(text_)));
+    }
+
+    // format outputs
+
+//    TString test1 = TString(convertUTF16StringToUTF8String(errBuf->str()));
+//    TString test2 = TString(convertUTF16StringToUTF8String(outBuf->str()));
+
+    TVector<double> res;
+    for(auto r : rest) {
+        for(auto elem : TypedArray<double>(r)) {
+            res.push_back(elem);
+        }
+    }
+
+    return res;
+}
+
+/*!
+ * A single variable is placed into the MATLAB workspace. The variable name is
+ * determined by \p name and its value is determined by \p value, workspace
+ * variable has a corresponding MATLAB type to type of \p value.
+ * \param name  The name of the workspace variable.
+ * \param value The value of the variable.
+ */
+void MatlabEngineX::placeVariable(const TString &name, int value)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    ArrayFactory factory;
+    auto val = factory.createScalar<int>(value);
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), std::move(val));
+}
+
+//! \overload placeVariable(const TString &name, int value)
+void MatlabEngineX::placeVariable(const TString &name, double value)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    ArrayFactory factory;
+    auto val = factory.createScalar<double>(value);
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), std::move(val));
+}
+
+//! \overload placeVariable(const TString &name, int value)
+void MatlabEngineX::placeVariable(const TString &name, bool value)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    ArrayFactory factory;
+    auto val = factory.createScalar<bool>(value);
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), std::move(val));
+}
+
+//! \overload placeVariable(const TString &name, int value)
+void MatlabEngineX::placeVariable(const TString &name, TComplex value)
+{
+    T_UNUSED(name);
+    T_UNUSED(value);
+
+    /// \todo
+}
+
+//! \overload placeVariable(const TString &name, int value)
+void MatlabEngineX::placeVariable(const TString &name, TString value)
+{
+    T_UNUSED(name);
+    T_UNUSED(value);
+
+    /// \todo
+}
+
+
+/*!
+ * \brief Place a column vector into the MATLAB workspace.
+ *
+ * A column vector named \p name is placed into the MATLAB workspace. This is
+ * the same length as \p vec. The values in the workspace vector are the same
+ * order as those in \p vec. The workspace variable has an equivalant MATLAB
+ * type to the type of values in \p vec.
+ * \param name
+ * \param vec
+ */
+void MatlabEngineX::placeVectorColumn(const TString &name, const TVector<int>& vec)
+{
+    setMatrix<int>(name, vec, vec.size(), 1);
+}
+
+//! \overload placeVectorColumn(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorColumn(const TString &name, const TVector<double>& vec)
+{
+    setMatrix<double>(name, vec, vec.size(), 1);
+}
+
+//! \overload placeVectorColumn(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorColumn(const TString &name, const TVector<bool>& vec)
+{
+    setMatrix<bool>(name, vec, vec.size(), 1);
+}
+
+//! \overload placeVectorColumn(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorColumn(const TString &name, const TVector<TComplex>& vec)
+{
+    T_UNUSED(name);
+    T_UNUSED(vec);
+
+    /// \todo
+}
+
+/*!
+ * \brief Place a row vector into the MATLAB workspace.
+ *
+ * A row vector named \p name is placed into the MATLAB workspace. This is the
+ * same length as \p vec. The values in the workspace vector are the same order
+ * as those in \p vec. The workspace variable has an equivalant MATLAB type to
+ * the type of values in \p vec.
+ * \param name
+ * \param vec
+ */
+void MatlabEngineX::placeVectorRow(const TString &name, const TVector<int>& vec)
+{
+    setMatrix<int>(name, vec, 1, vec.size());
+}
+
+//! \overload placeVectorRow(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorRow(const TString &name, const TVector<double>& vec)
+{
+    setMatrix<double>(name, vec, 1, vec.size());
+}
+
+//! \overload placeVectorRow(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorRow(const TString &name, const TVector<bool>& vec)
+{
+    setMatrix<bool>(name, vec, 1, vec.size());
+}
+
+//! \overload placeVectorRow(const TString &name, TVector<int> vec)
+void MatlabEngineX::placeVectorRow(const TString &name, const TVector<TComplex>& vec)
+{
+    T_UNUSED(name);
+    T_UNUSED(vec);
+
+    /// \todo
+}
+
+/*!
+ * \brief Place a 2D matrix into the MATLAB workspace.
+ *
+ * A 2D matrix \p mat is placed into the MATLAB workspace named \p name. \p mat
+ * must be index by row-column order, i.e mat[row][col]. If all rows of \p mat
+ * are not of the same length this operator fails silently, it returns without
+ * having written any value to the workspace.
+ * \param name  Name of the matrix in the workspace.
+ * \param mat   A 2D Vector (Vector of Vectors) containing the matrix.
+ */
+void MatlabEngineX::placeMatrix(const TString &name,
+                                const TVector<TVector<int>>& mat)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    auto nRows = mat.size();
+    auto nCols = mat[0].size();
+    auto size = nRows*nCols;
+
+    // copy the elements of the matrix into a vector in column-major order
+    TVector<int> cmo;
+    cmo.reserve(size);
+    for(size_t i=0; i<nCols; i++) {
+        for(size_t j=0; j<nRows; j++) {
+            cmo.push_back(mat[j][i]);
+        }
+    }
+
+    ArrayFactory factory;
+    TypedArray<int> data = factory.createArray({ mat.size(), mat[0].size() },
+                                               cmo.begin(), cmo.end());
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), data);
+}
+
+//! \overload
+void MatlabEngineX::placeMatrix(const TString &name,
+                                const TVector<TVector<double>>& mat)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    auto nRows = mat.size();
+    auto nCols = mat[0].size();
+    auto size = nRows*nCols;
+
+    // copy the elements of the matrix into a vector in column-major order
+    TVector<double> cmo;
+    cmo.reserve(size);
+    for(size_t i=0; i<nCols; i++) {
+        for(size_t j=0; j<nRows; j++) {
+            cmo.push_back(mat[j][i]);
+        }
+    }
+
+    ArrayFactory factory;
+    TypedArray<double> data = factory.createArray({ mat.size(), mat[0].size() },
+                                                   cmo.begin(), cmo.end());
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), data);
+}
+
+//! \overload
+void MatlabEngineX::placeMatrix(const TString &name,
+                                const TVector<TVector<bool>>& mat)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    auto nRows = mat.size();
+    auto nCols = mat[0].size();
+    auto size = nRows*nCols;
+
+    // copy the elements of the matrix into a vector in column-major order
+    TVector<bool> cmo;
+    cmo.reserve(size);
+    for(size_t i=0; i<nCols; i++) {
+        for(size_t j=0; j<nRows; j++) {
+            cmo.push_back(mat[j][i]);
+        }
+    }
+
+    ArrayFactory factory;
+    TypedArray<bool> data = factory.createArray({ mat.size(), mat[0].size() },
+                                                  cmo.begin(), cmo.end());
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), data);
+}
+
+//! \overload
+void MatlabEngineX::placeMatrix(const TString &name, const TVector<TVector<TComplex>>& mat)
+{
+    T_UNUSED(name);
+    T_UNUSED(mat);
+
+    /// \todo
+}
+
+/*!
+ * \brief Retreive a variable from the MATLAB workspace.
+ *
+ * Retreives the MATLAB workspace variable called \p name and places it into \p
+ * value. Any existing value of \p value is overwritten. If no workspace variable
+ * called \p name is found then \p value is unchanged.
+ * \param[in] name      The name of the function to retreive from the workspace.
+ * \param[out] value    A reference to where the workspace variable will be placed.
+ */
+bool MatlabEngineX::getWorkspaceVariable(const TString &name, int& value)
+{
+    return getValue<int>(name, value);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+bool MatlabEngineX::getWorkspaceVariable(const TString &name, double& value)
+{
+    return getValue<double>(name, value);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+bool MatlabEngineX::getWorkspaceVariable(const TString &name, bool& value)
+{
+    return getValue<bool>(name, value);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+bool MatlabEngineX::getWorkspaceVariable(const TString &name, TComplex& value)
+{
+    T_UNUSED(name);
+    T_UNUSED(value);
+
+    /// \todo
+
+    return true;
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+bool MatlabEngineX::getWorkspaceVariable(const TString &name, TString& value)
+{
+    T_UNUSED(name);
+    T_UNUSED(value);
+
+    /// \todo
+
+    return true;
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<int>& vec)
+{
+    return getVector<int>(name, vec);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<double>& vec)
+{
+    return getVector<double>(name, vec);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<bool>& vec)
+{
+    return getVector<bool>(name, vec);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name, TVector<TComplex>& vec)
+{
+    T_UNUSED(name);
+    T_UNUSED(vec);
+
+    /// \todo
+
+    return TVector<int>();
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<TVector<int>>& mat)
+{
+    return getMatrix<int>(name, mat);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<TVector<double>>& mat)
+{
+    return getMatrix<double>(name, mat);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name,
+                                                 TVector<TVector<bool>>& mat)
+{
+    return getMatrix<bool>(name, mat);
+}
+
+//! \overload getWorkspaceVariable(const TString &name, int& value)
+TVector<int> MatlabEngineX::getWorkspaceVariable(const TString &name, TVector<TVector<TComplex>>& mat)
+{
+    T_UNUSED(name);
+    T_UNUSED(mat);
+
+    /// \todo
+
+    return TVector<int>();
+}
+
+
+/*!
+ * \brief Deprecated, his engine does not have an interactive state.
+ * \param visible
+ */
+void MatlabEngineX::setInteractive(bool visible)
+{
+    T_UNUSED(visible);
+}
+
+/*!
+ * \brief Deprecated, this engine does not have an interactive state.
+ * \param visible
+ */
+bool MatlabEngineX::Interactive()
+{
+    return true;
+}
+
+} //namespace Tigon

--- a/src/libs/matlabplugin/Utils/MatlabEngineX.h
+++ b/src/libs/matlabplugin/Utils/MatlabEngineX.h
@@ -1,0 +1,290 @@
+/****************************************************************************
+**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
+**
+** This file is part of Liger.
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+****************************************************************************/
+#ifndef MATLABENGINEX_H
+#define MATLABENGINEX_H
+
+#include <matlabplugin/Utils/IMatlabEngine.h>
+
+#include "MatlabEngine.hpp"
+#include "MatlabDataArray.hpp"
+
+namespace Tigon {
+
+using namespace matlab::engine;
+using namespace matlab::data;
+using SBuf = std::basic_stringbuf<char16_t>;
+
+class LIGER_TIGON_EXPORT MatlabEngineX : public IMatlabEngine
+{
+    friend class MatlabPool;
+
+public:
+    bool evaluateString(const TString& command, bool errorCatch = true);
+    TVector<double> evaluateFunction(const TString& funcName,
+                                     const size_t nOutputs,
+                                     const TVector<double>& in,
+                                     bool errorCatch = true);
+    void resetEngine();
+
+    void setInteractive(bool visible);
+    bool Interactive();
+
+    void placeVariable(const TString &name, int value);
+    void placeVariable(const TString &name, double value);
+    void placeVariable(const TString &name, bool value);
+    void placeVariable(const TString &name, TComplex value);
+    void placeVariable(const TString &name, TString value);
+
+    void placeVectorColumn(const TString &name, const TVector<int>& vec);
+    void placeVectorColumn(const TString &name, const TVector<double>& vec);
+    void placeVectorColumn(const TString &name, const TVector<bool>& vec);
+    void placeVectorColumn(const TString &name, const TVector<TComplex>& vec);
+
+    void placeVectorRow(const TString &name, const TVector<int>& vec);
+    void placeVectorRow(const TString &name, const TVector<double>& vec);
+    void placeVectorRow(const TString &name, const TVector<bool>& vec);
+    void placeVectorRow(const TString &name, const TVector<TComplex>& vec);
+
+    void placeMatrix(const TString &name, const TVector<TVector<int>>& mat);
+    void placeMatrix(const TString &name, const TVector<TVector<double>>& mat);
+    void placeMatrix(const TString &name, const TVector<TVector<bool>>& mat);
+    void placeMatrix(const TString &name, const TVector<TVector<TComplex>>& mat);
+
+
+    bool getWorkspaceVariable(const TString &name, int& value);
+    bool getWorkspaceVariable(const TString &name, double& value);
+    bool getWorkspaceVariable(const TString &name, bool& value);
+    bool getWorkspaceVariable(const TString &name, TComplex& value);
+    bool getWorkspaceVariable(const TString &name, TString& value);
+
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<int>& vec);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<double>& vec);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<bool>& vec);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<TComplex>& vec);
+
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<int>>& mat);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<double>>& mat);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<bool>>& mat);
+    TVector<int> getWorkspaceVariable(const TString &name, TVector<TVector<TComplex>>& mat);
+
+    ~MatlabEngineX();
+
+private:
+    MatlabEngineX();
+    void openEngine();
+    void closeEngine();
+
+    template<typename T>
+    bool getValue(const TString &name, T& val);
+    template<typename T>
+    TVector<int> getVector(const TString &name, TVector<T>& vec);
+    template<typename T>
+    TVector<int> getMatrix(const TString &name, TVector<TVector<T>>& mat);
+
+    template<typename T>
+    void setMatrix(const TString &name, const TVector<T>& source, size_t rows, size_t cols);
+    template<typename T>
+    void setMatrix(const TString &name, const TVector<TVector<T>>& source, size_t rows, size_t cols);
+//    template<typename T>
+//    void setMatrix(const TString &name, TVector<TComplex>& source, int rows, int cols);
+//    template<typename T>
+//    void setMatrix(const TString &name, TVector<TVector<TComplex>>& source, int rows, int cols);
+
+    std::unique_ptr<MATLABEngine> m_engine;
+};
+
+/*!
+ * \brief Place a 1D vector into the MATLAB workspace.
+ *
+ * Places a 1D columnwise matrix or vector into the MATLAB workspace, values
+ * in\p source are unchanged.
+ * \param name      Name of the matrix.
+ * \param source    The matrix to be copied to the workspace.
+ * \param rows      Number of rows in the matrix.
+ * \param cols      Number of columns in the matrix.
+ */
+template<typename T>
+void MatlabEngineX::setMatrix(const TString &name, const TVector<T>& source,
+                              size_t rows, size_t cols)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    ArrayFactory factory;
+    TypedArray<T> data = factory.createArray({ rows, cols }, source.begin(), source.end());
+    m_engine->setVariable(convertUTF8StringToUTF16String(name), std::move(data));
+}
+
+/*!
+ * \overload
+ * \brief Place a 2D vector into the MATLAB workspace.
+ *
+ * Places a 2D matrix into the MATLAB workspace, values in \p source are unchanged.
+ * \param name      Name of the matrix.
+ * \param source    The matrix to be copied to the workspace.
+ * \param rows      Number of rows in the matrix.
+ * \param cols      Number of columns in the matrix.
+ */
+template<typename T>
+void MatlabEngineX::setMatrix(const TString &name, const TVector<TVector<T>>& source,
+                              size_t rows, size_t cols)
+{
+    TVector<T> tmp;
+    for(size_t c = 0; c < cols; c++) {
+        for(size_t r = 0; r < rows; r++) {
+            tmp.push_back(source[r][c]);
+        }
+    }
+
+    setMatrix(name, tmp, rows, cols);
+}
+
+/*!
+ * \overload getWorkspaceVariable(const TString &name, int& value)
+ * \brief Retrieves a value from the workspace.
+ *
+ * Retrieves a value from the MATLAB workspace. Any existing value of \p val is
+ * overwritten.
+ * \param[in]   name    Name of the variable in the workspace
+ * \parma[out]  val     Where the retrieved value is placed
+ * \return      True if the value could be retrieved successfully, or false otherwise.
+ */
+template<typename T>
+bool MatlabEngineX::getValue(const TString &name, T& val)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    auto A = m_engine->getVariable(convertUTF8StringToUTF16String(name));
+    auto d = A.getDimensions();
+
+    if(d[0]>0) {
+        val = static_cast<T>(A[0]);
+        return true;
+    }
+
+    return false;
+}
+
+/*!
+ * \overload getWorkspaceVariable(const TString &name, int& value)
+ * \brief Retreives a 1D vector from the MATLAB workspace.
+ *
+ * Retrieves a 1D vector from the MATLAB workspace. Any existing value of \p vec is overwritten.
+ * \param[in]   name    Name of the matrix in the workspace
+ * \parma[out]  vec     1D TVector where matrix will be placed
+ * \return      Dimensions of the retireved matrix (rows, cols)
+ */
+template<typename T>
+TVector<int> MatlabEngineX::getVector(const TString &name, TVector<T>& vec)
+{
+    if(!m_engine) {
+        openEngine();
+    }
+
+    auto A = m_engine->getVariable(convertUTF8StringToUTF16String(name));
+    auto d = A.getDimensions();
+    auto c = A.getType();
+
+    TVector<int> dimensions;
+    for(auto e : d) {
+        dimensions.push_back(static_cast<int>(e));
+    }
+
+    switch(c) {
+        case ArrayType::INT8:
+        case ArrayType::UINT8:
+        case ArrayType::INT16:
+        case ArrayType::UINT16:
+        case ArrayType::INT32:
+        case ArrayType::UINT32:
+        case ArrayType::INT64:
+        case ArrayType::UINT64:
+        {
+            auto B = TypedArray<int>(A);
+
+            vec.clear();
+            vec.reserve(A.getNumberOfElements());
+            for(auto e : B) {
+                vec.push_back( static_cast<T>(e) );
+            }
+            break;
+        }
+        case ArrayType::DOUBLE:
+        {
+            auto B = TypedArray<double>(A);
+
+            vec.clear();
+            vec.reserve(A.getNumberOfElements());
+            for(auto e : B) {
+                vec.push_back( static_cast<T>(e) );
+            }
+            break;
+        }
+        case ArrayType::LOGICAL:
+        {
+            auto B = TypedArray<bool>(A);
+
+            vec.clear();
+            vec.reserve(A.getNumberOfElements());
+            for(auto e : B) {
+                vec.push_back( static_cast<T>(e) );
+            }
+            break;
+        }
+    }
+
+    return dimensions;
+}
+
+/*!
+ * \overload getWorkspaceVariable(const TString &name, int& value)
+ * \brief Retreives a 2D matrix from the MATLAB workspace.
+ *
+ * Retrieves a 2D matrix from the MATLAB workspace. Any existing value of \p mat
+ * is overwritten.
+ * \param[in]   name    Name of the matrix in the workspace
+ * \parma[out]  vec     2D TVector where matrix will be placed
+ * \return      Dimensions of the retireved matrix (rows, cols)
+ */
+template<typename T>
+TVector<int> MatlabEngineX::getMatrix(const TString &name, TVector<TVector<T>>& mat)
+{
+    TVector<T> flatMat;
+    // Get the matrix as a 1D columnwise TVector and convert to a 2D TVector
+    TVector<int> dimensions = getWorkspaceVariable(name, flatMat);
+
+    int rows = dimensions[0];
+    int cols = dimensions[1];
+
+    mat.resize(rows);
+
+    for (int r = 0; r < rows; r++) {
+        mat[r].resize(cols);
+        for (int c = 0; c < cols; c++) {
+            mat[r][c] = flatMat[(c*rows) + r];
+        }
+    }
+
+    return dimensions;
+}
+
+
+} // Tigon
+
+#endif // MATLABENGINEX_H

--- a/src/libs/matlabplugin/Utils/MatlabPool.h
+++ b/src/libs/matlabplugin/Utils/MatlabPool.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **
@@ -22,7 +21,15 @@
 #include <mutex>
 
 namespace Tigon {
-class MatlabEngine;
+class IMatlabEngine;
+
+#ifdef MATLAB_API_C
+class MatlabEngineC;
+#endif
+
+#ifdef MATLAB_API_CPP
+class MatlabEngineX;
+#endif
 /*!
  * \brief A resource pool of <MatlabEngine>'s
  *
@@ -45,8 +52,8 @@ public:
     void defineMaxPoolSize(int size);
     static MatlabPool& getInstance(); // Meyers singleton
     static bool useMatlab();
-    MatlabEngine* aquireEngine();
-    void releaseEngine(MatlabEngine* eng);
+    IMatlabEngine* aquireEngine();
+    void releaseEngine(IMatlabEngine* eng);
     void emptyPool();
 
     ~MatlabPool();
@@ -54,10 +61,10 @@ public:
 private:
     MatlabPool();
 
-    TVector<MatlabEngine* > m_unlocked; //!< Holds free <MatlabEngine>s to be used.
-    TVector<MatlabEngine* > m_locked;  //!< Holds <MatlabEngine>s currently being used.
+    TVector<IMatlabEngine*> m_unlocked; //!< Holds free <MatlabEngine>s to be used.
+    TVector<IMatlabEngine*> m_locked;  //!< Holds <MatlabEngine>s currently being used.
     std::mutex m_mutex;
-    int m_maxUnlocked;
+    size_t m_maxUnlocked;
 };
 
 } // Tigon

--- a/src/libs/matlabplugin/matlab.pri
+++ b/src/libs/matlabplugin/matlab.pri
@@ -1,24 +1,27 @@
+
+# Defines the include and library paths (and others) for Matlab
+
 !contains(CONFIG, NO_MATLAB) {
+
 include(../../../matlabcheck.pri)
 
-# Check if Matlab exists, if so set MATLAB_ROOT_PATH
-#!exists(MATLAB_ROOT_PATH) {
 linux-* {
-#    !isEmpty(MATLAB_ROOT_PATH) {
-#      LIBS += -L$$MATLAB_LIB_PATH/ -leng -lmx -lm -lstdc++
-#      INCLUDEPATH += $$MATLAB_INCLUDE_PATH
-#      DEPENDPATH  += $$MATLAB_INCLUDE_PATH
+  isEmpty(MATLAB_ROOT_PATH) {
+    message("A compatible Matlab installation could not be found.")
+  }
+  !isEmpty(MATLAB_ROOT_PATH) {
 
-#      QMAKE_RPATHDIR += $$(QTDIR)/lib
-#      QMAKE_RPATHDIR += $$MATLAB_LIB_PATH
-#      QMAKE_RPATHDIR += $${MATLAB_ROOT_PATH}/sys/os/glnxa64
-#    }
+    message("A compatible Matlab installation has been found in $$MATLAB_ROOT_PATH")
 
-#    isEmpty(MATLAB_ROOT_PATH) {
-#      message("A compatible Matlab installation could not be found.")
-#    }
-#  }
-}
+    LIBS += -L$$MATLAB_LIB_PATH/ -pthread -lMatlabDataArray -lMatlabEngine -lstdc++
+    INCLUDEPATH += $$MATLAB_INCLUDE_PATH
+    DEPENDPATH  += $$MATLAB_INCLUDE_PATH
+
+    QMAKE_RPATHDIR += $$(QTDIR)/lib
+    QMAKE_RPATHDIR += $$MATLAB_LIB_PATH
+    QMAKE_RPATHDIR += $${MATLAB_ROOT_PATH}/sys/os/glnxa64
+  }
+} # end linux
 
 macx {
   isEmpty(MATLAB_ROOT_PATH) {
@@ -35,16 +38,29 @@ macx {
     QMAKE_RPATHDIR += $$MATLAB_LIB_PATH
     QMAKE_RPATHDIR += $${MATLAB_ROOT_PATH}/sys/os/maci64
   }
-}
+} # end macx
 
 win32 {
   isEmpty(MATLAB_ROOT_PATH) {
     message("A compatible Matlab installation could not be found.")
   }
   !isEmpty(MATLAB_ROOT_PATH) {
-    LIBS += -L$$MATLAB_LIB_PATHB -llibmx -llibmex -llibmat -llibeng
+
+    message("A compatible Matlab installation has been found in $$MATLAB_ROOT_PATH")
+
+    contains(DEFINES, MATLAB_API_CPP) {
+      LIBS += -L$$MATLAB_LIB_PATHB
+      LIBS += $$MATLAB_LIB_PATHB/libMatlabEngine.lib
+      LIBS += $$MATLAB_LIB_PATHB/libMatlabDataArray.lib
+    }
+
+    contains(DEFINES, MATLAB_API_C) {
+      LIBS += -L$$MATLAB_LIB_PATHB -llibmx -llibmex -llibmat -llibeng
+    }
+
     INCLUDEPATH += $$MATLAB_INCLUDE_PATH
     DEPENDPATH  += $$MATLAB_INCLUDE_PATH
   }
-}
-}
+} # end win32
+
+} # check if NO_MATLAB is defined

--- a/src/libs/matlabplugin/matlabplugin.pro
+++ b/src/libs/matlabplugin/matlabplugin.pro
@@ -10,20 +10,31 @@ dll {
     DEFINES += LIGER_TIGON_STATIC_LIB
 }
 
-HEADERS += MatlabPlugin.h
-SOURCES += MatlabPlugin.cpp
+HEADERS += MATLABPlugin.h
+SOURCES += MATLABPlugin.cpp
 
 # Include matlab support
 !isEmpty(MATLAB_ROOT_PATH) {
     HEADERS += \
         Representation/Functions/Matlab/MatlabFunction.h \
         Utils/MatlabPool.h \
-        Utils/MatlabEngine.h
+        Utils/IMatlabEngine.h
 
     SOURCES += \
         Representation/Functions/Matlab/MatlabFunction.cpp \
         Utils/MatlabPool.cpp \
-        Utils/MatlabEngine.cpp
+        Utils/IMatlabEngine.cpp
+
+    contains(DEFINES, MATLAB_API_CPP) {
+       HEADERS += Utils/MatlabEngineX.h
+       SOURCES += Utils/MatlabEngineX.cpp
+    }
+
+    contains(DEFINES, MATLAB_API_C) {
+       HEADERS += Utils/MatlabEngineC.h
+       SOURCES += Utils/MatlabEngineC.cpp
+    }
+
 }
 
 # Boost

--- a/src/libs/tigon/Operators/Filtrations/RandSetReplacement.cpp
+++ b/src/libs/tigon/Operators/Filtrations/RandSetReplacement.cpp
@@ -1,8 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-** Copyright (C) 2016 Joao A. Duro (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/libs/tigon/Operators/Filtrations/TruncateSets.cpp
+++ b/src/libs/tigon/Operators/Filtrations/TruncateSets.cpp
@@ -1,8 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-** Copyright (C) 2016 Joao A. Duro (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/libs/tigon/tigon_pch.h
+++ b/src/libs/tigon/tigon_pch.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/outputpropertiesdialog.cpp
+++ b/src/plugins/qtigon/dialogs/outputpropertiesdialog.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/outputpropertiesdialog.h
+++ b/src/plugins/qtigon/dialogs/outputpropertiesdialog.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/populationviewer.cpp
+++ b/src/plugins/qtigon/dialogs/populationviewer.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/populationviewer.h
+++ b/src/plugins/qtigon/dialogs/populationviewer.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/qalgorithmdialog.h
+++ b/src/plugins/qtigon/dialogs/qalgorithmdialog.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/qoperatordiag.h
+++ b/src/plugins/qtigon/dialogs/qoperatordiag.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/dialogs/qoperatordiagtabitem.cpp
+++ b/src/plugins/qtigon/dialogs/qoperatordiagtabitem.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/masterstartnode.cpp
+++ b/src/plugins/qtigon/masterstartnode.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/masterstartnode.h
+++ b/src/plugins/qtigon/masterstartnode.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornode.cpp
+++ b/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornode.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornode.h
+++ b/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornode.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornodefactory.cpp
+++ b/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornodefactory.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornodefactory.h
+++ b/src/plugins/qtigon/operators/problemgenerator/qopprobgeneratornodefactory.h
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
-**
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/plugins/texteditor/generichighlighter/highlightdefinitionhandler.h
+++ b/src/plugins/texteditor/generichighlighter/highlightdefinitionhandler.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/liger_gui_pch.h
+++ b/src/shared/liger_gui_pch.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/liger_pch.h
+++ b/src/shared/liger_pch.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtlockedfile/qtlockedfile.cpp
+++ b/src/shared/qtlockedfile/qtlockedfile.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtlockedfile/qtlockedfile.h
+++ b/src/shared/qtlockedfile/qtlockedfile.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtlockedfile/qtlockedfile_unix.cpp
+++ b/src/shared/qtlockedfile/qtlockedfile_unix.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtlockedfile/qtlockedfile_win.cpp
+++ b/src/shared/qtlockedfile/qtlockedfile_win.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/shared/qtsingleapplication/qtlocalpeer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtsingleapplication/qtlocalpeer.h
+++ b/src/shared/qtsingleapplication/qtlocalpeer.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtsingleapplication/qtsingleapplication.cpp
+++ b/src/shared/qtsingleapplication/qtsingleapplication.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/src/shared/qtsingleapplication/qtsingleapplication.h
+++ b/src/shared/qtsingleapplication/qtsingleapplication.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2012-2017 The University of Sheffield (www.sheffield.ac.uk)
+** Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
 **
 ** This file is part of Liger.
 **

--- a/tests/auto/test_tigon/test_matlabintegration/test_matlabintegration.pro
+++ b/tests/auto/test_tigon/test_matlabintegration/test_matlabintegration.pro
@@ -27,6 +27,7 @@ MATLAB_TEST_FILES += \
     test_mfunctions/test7_tigonBadStruct.m \
     test_mfunctions/test8_tigonBadStruct.m \
     test_mfunctions/test_matlabfunction_workflow.lgr \
-    test_mfunctions/DTLZ1.m
+    test_mfunctions/DTLZ1.m \
+    test_mfunctions/DTLZ2.m
 
 copyToDir($$MATLAB_TEST_FILES, $$TEST_BIN_PATH)

--- a/tests/auto/test_tigon/test_matlabintegration/test_mfunctions/DTLZ2.m
+++ b/tests/auto/test_tigon/test_matlabintegration/test_mfunctions/DTLZ2.m
@@ -1,0 +1,84 @@
+%#<TIGON_MATLAB_FUNC_HEADER_START>
+%# {
+%# 	"functionProperties": {
+%# 		"name": "DTLZ2",
+%# 		"description": "DTLZ2 Matlab Version"
+%# 	},
+%# 	"input": {
+%# 		"name": ["x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12"],
+%# 		"description": ["x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12"],
+%# 		"type": ["real", "real", "real", "real", "real", "real", "real", "real", "real", "real", "real", "real"],
+%# 		"unit": ["", "", "", "", "", "", "", "", "", "", "", ""],
+%#      "lbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+%#      "ubounds": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+%# 	},
+%# 	"output": {
+%# 		"name": ["y1", "y2", "y3"],
+%# 		"description": ["y1", "y2", "y3"],
+%# 		"type": ["real", "real", "real"],
+%# 		"unit": ["", "", ""]
+%# 	}
+%# }
+%#<TIGON_MATLAB_FUNC_HEADER_END>
+
+function varargout = DTLZ2( varargin )
+% DTLZ2 with 12 decision variables and 3 objectives
+% ----------------------------------------------------------
+% Define Evaluation function here
+% Edit the following block to define your evaluation functions
+% ----------------------------------------------------------
+x = cell2mat(varargin);
+y = dtlz2_func(x, 3, 12);
+
+% ----------------------------------------------------------
+% End of editing.
+% ----------------------------------------------------------
+disp(nargout)
+if nargout == 1 
+    varargout{1} = y;
+else
+    varargout = num2cell(y);
+end
+
+end
+
+function f = dtlz2_func(x, M, N)
+% f = dtlz2_func(x, M, N)
+%
+% Inputs: x      - Candidate solutions
+%         M      - Number of objectives
+%         N      - Number of decision variables
+%
+% Output: f      - Objective Values
+%
+% Minimization problem
+% Constraints: Decision variables in [0,1]
+% Optimal solution: xm = [0.5...0.5], Sum(fn) = 0.5 hyperplane.
+
+if(M>N)
+    error('Cannot have more objectives than decision variables.');
+end
+
+k = N-M+1;
+nind = size(x,1);
+
+% Set-up the output matrix.
+f = NaN*ones(nind, M);
+
+% Compute 'g' functional.
+xm = x(:,M:N)';
+if k > 0
+    g = sum((xm - 0.5).^2);
+else
+    g = 0;
+end
+
+% Compute the objectives.
+opg = 1+g';
+f(:,1) = prod(cos(pi/2*x(:,1:M-1)),2).*opg;
+for n = 2:M-1
+   f(:,n) = prod(cos(pi/2*x(:,1:M-n)),2).*sin(pi/2*x(:,M-n+1)).*opg;
+end
+f(:,M) = sin(pi/2*x(:,1)).*opg;
+
+end

--- a/tests/auto/test_tigon/test_matlabintegration/test_mfunctions/test_matlabfunction_workflow.lgr
+++ b/tests/auto/test_tigon/test_matlabintegration/test_mfunctions/test_matlabfunction_workflow.lgr
@@ -5,8 +5,10 @@
       <NodeId>08a4b561-0d5e-48a0-84a2-4f2d525ab8b9</NodeId>
       <xpos>-607</xpos>
       <ypos>-125</ypos>
+      <isUserDefinedSeed>false</isUserDefinedSeed>
+      <userDefinedSeed>0</userDefinedSeed>
     </GUIProperties>
-    <Properties/>
+    <Properties ProcessType="MASTER_START_NODE"/>
   </ProcessNode>
   <ProcessNode ClassName="QTigon::QOpProbGeneratorNode">
     <GUIProperties>
@@ -25,7 +27,10 @@
       <ubounds>[{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1}]</ubounds>
       <paramValueVec>[]</paramValueVec>
       <externalParam>[]</externalParam>
+      <externalParamGroups>[]</externalParamGroups>
+      <setGoals>[false,false]</setGoals>
       <goals>[{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:-8.9884656743115785e+307},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:-8.9884656743115785e+307}]</goals>
+      <priorities>[{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1},{&quot;type&quot;:&quot;Real Type&quot;,&quot;value&quot;:1}]</priorities>
       <thresholds>[]</thresholds>
       <dVecUncertainties>[{},{},{},{},{}]</dVecUncertainties>
       <funcOutUncertainties>[[{},{}]]</funcOutUncertainties>
@@ -33,6 +38,7 @@
       <f2pMap>[[]]</f2pMap>
       <f2oMap>[[0,1]]</f2oMap>
       <f2cMap>[[]]</f2cMap>
+      <f2uMap>[[]]</f2uMap>
     </Properties>
   </ProcessNode>
   <ProcessNode ClassName="QTigon::QOpRandomInitNode">
@@ -45,11 +51,6 @@
       <TigonOperator>Tigon::Operators::RandomInit</TigonOperator>
       <OutputTags>MAIN_OPTIMIZATION_SET;FOR_EVALUATION</OutputTags>
       <OptimizationSetSize>100</OptimizationSetSize>
-      <InitialSet>{
-    &quot;Single Population&quot;: [
-    ]
-}
-</InitialSet>
     </Properties>
   </ProcessNode>
   <ProcessNode ClassName="QTigon::QOpEvaluatorNode">
@@ -76,9 +77,20 @@
     <Properties ProcessType="ALGORITHM_NODE">
       <TigonAlgorithm>Tigon::Algorithms::NSGAII</TigonAlgorithm>
       <TigonOperator>
+        <Name>Tigon::Operators::StrategyVariablesInit</Name>
+        <OutputTags>MAIN_OPTIMIZATION_SET;FOR_EVALUATION</OutputTags>
+        <OptimizationSetSize>0</OptimizationSetSize>
+        <UseStrategyVariables>false</UseStrategyVariables>
+        <WidthPercentReal>0.1</WidthPercentReal>
+        <WidthPercentInteger>0.33</WidthPercentInteger>
+      </TigonOperator>
+      <TigonOperator>
         <Name>Tigon::Operators::NonDominanceRanking</Name>
         <OutputTags>FOR_SELECTION;FITNESS</OutputTags>
-        <InputTags>MAIN_OPTIMIZATION_SET</InputTags>
+	<InputTags>MAIN_OPTIMIZATION_SET</InputTags>
+	<IsConstrainedHandlingUsed>true</IsConstrainedHandlingUsed>
+        <IsPreferabilityUsed>true</IsPreferabilityUsed>
+        <IsWeakDom>true</IsWeakDom>
       </TigonOperator>
       <TigonOperator>
         <Name>Tigon::Operators::NSGAIICrowding</Name>
@@ -100,25 +112,39 @@
         <Name>Tigon::Operators::SBXCrossOver</Name>
         <OutputTags>FOR_DIRECTION</OutputTags>
         <SupportedElementTypes>Real Type;Integer Type</SupportedElementTypes>
-        <SolutionCrossoverProbability>0.90000000000000002</SolutionCrossoverProbability>
+        <SolutionCrossoverProbability>0.9</SolutionCrossoverProbability>
         <VariableCrossoverProbability>0.5</VariableCrossoverProbability>
         <VariableSwapCrossoverProbability>0.5</VariableSwapCrossoverProbability>
         <CrossoverDistributionIndex>15</CrossoverDistributionIndex>
+      </TigonOperator>
+      <TigonOperator>
+        <Name>Tigon::Operators::DiscreteCrossover</Name>
+        <OutputTags>FOR_DIRECTION</OutputTags>
+        <SolutionCrossoverProbability>0.9</SolutionCrossoverProbability>
+        <VariableCrossoverProbability>0.5</VariableCrossoverProbability>
+        <VariableSwapCrossoverProbability>0.5</VariableSwapCrossoverProbability>
       </TigonOperator>
       <TigonOperator>
         <Name>Tigon::Operators::PolynomialMutation</Name>
         <OutputTags>FOR_PERTURBATION</OutputTags>
         <SupportedElementTypes>Real Type;Integer Type</SupportedElementTypes>
         <SolutionMutationProbability>1</SolutionMutationProbability>
-        <VariableMutationProbability>0.10000000000000001</VariableMutationProbability>
+        <VariableMutationProbability>0.1</VariableMutationProbability>
         <MutationDistributionIndex>20</MutationDistributionIndex>
+      </TigonOperator>
+      <TigonOperator>
+        <Name>Tigon::Operators::IntegerMutation</Name>
+        <OutputTags>FOR_PERTURBATION</OutputTags>
+        <SolutionMutationProbability>1</SolutionMutationProbability>
+        <VariableMutationProbability>0.1</VariableMutationProbability>
+        <WidthPercent>0.1</WidthPercent>
       </TigonOperator>
       <TigonOperator>
         <Name>Tigon::Operators::CategoricalPerturpation</Name>
         <OutputTags>FOR_PERTURBATION</OutputTags>
         <SupportedElementTypes>Nominal Type;Ordinal Type</SupportedElementTypes>
         <SolutionMutationProbability>1</SolutionMutationProbability>
-        <VariableMutationProbability>0.10000000000000001</VariableMutationProbability>
+        <VariableMutationProbability>0.1</VariableMutationProbability>
       </TigonOperator>
       <TigonOperator>
         <Name>Tigon::Operators::MergeForNextIteration</Name>


### PR DESCRIPTION
The Matlab plugin makes uses of the Matlab C++ API, first introduced in Matlab version 2017b. Prior to this, the Matlab plugin has been utilising the Matlab C API, which is only available for Matlab version up-to 2017b on Microsoft Windows.

Main points:

* The Matlab C++ API works on Linux and also Microsoft Windows.
* The Matlab Engine is managed by a design pattern, known as Object Pool (the class name in Tigon is MatlabPool). This design pattern recycles the Matlab Engine objects, and is responsible for their acquisition and release.
* qmake script for detecting the existence of a Matlab installation has been updated. For Windows, if Matlab version found is between 2013b and 2017a, then the Matlab C API is used; if Matlab version found is between 2017b and 2020b, then the Matlab C++ API is used instead. For Linux, the script identifies the installed Matlab version between versions 2017b and 2020b only.
* Test in test_matlabintegration have been adapted to test the Matlab C++ API.