### PR TITLE
Fix to Windows installer and update project readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ verifies the fix)!
    * Python2.7 (for python interface)
    * Optional: MATLAB (for MATLAB interface)
    * On Windows:
+     - Microsoft Visual C++ 2015 to 2019
+     - [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
      - jom
-     - MSVC 2015
    * On Mac: Xcode (Clang)
    * On Linux: 
      - g++
@@ -87,19 +88,22 @@ You can build Liger with the following commands.
 
 Windows 
 ```
-    qmake ../liger.pro -r -spec win32-msvc2015 "BOOST_INCLUDE=/path/to/boost/headers" "BOOST_LIB=/path/to/bootlibs"
+    qmake ../liger.pro -r -spec win32-msvc2015 "BOOST_INCLUDE=/path/to/boost/headers" "BOOST_LIB=/path/to/bootlibs" "BOOST_PYTHON_LIB=/path/to/bootlibs"
     jom
 ```
 
 Mac: 
 ```
-    qmake ../liger.pro -r -spec macx-clang "BOOST_INCLUDE=/path/to/boost/headers" "BOOST_LIB=/path/to/bootlibs"
+    qmake ../liger.pro -r -spec macx-clang "BOOST_INCLUDE=/path/to/boost/headers" "BOOST_LIB=/path/to/bootlibs" "BOOST_PYTHON_LIB=/path/to/bootlibs"
     make 
 ```
 
 Linux: 
 ```
-    qmake ../liger.pro -r -spec linux-g++ "BOOST_INCLUDE=/path/to/boost/headers" "BOOST_LIB=/path/to/bootlibs"
+    export BOOST_INCLUDE=/path/to/boost/headers
+    export BOOST_LIB=/path/to/bootlibs
+    export BOOST_PYTHON_LIB=/path/to/bootlibs
+    qmake ../liger.pro -r -spec linux-g++
     make 
 ```
 
@@ -112,6 +116,19 @@ make install INSTALL_ROOT=$INSTALL_DIRECTORY
 Alternatively, Qt Creator can be used to configure and compile Liger. This 
 is recommended for Developers.
 
-## Developer Notes
+## License
 
-There is a number of TODOs of known problems. So there's much to be done!
+This software is Copyright (C) 2012-2021 The University of Sheffield (www.sheffield.ac.uk)
+
+This program is free software (software libre); you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License (LGPL) version 3 as published by the Free Software Foundation. Please review the following information to ensure the GNU Lesser General Public License version 3 requirements will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+Although Liger is released as Free Software, it does not excuse you from scientific propriety, which obligates you to give appropriate credit! If you write a scientific paper describing research that made substantive use of this program, it is your obligation as a scientist to (a) mention the fashion in which this software was used in the Methods section; (b) mention the algorithm in the References section. The appropriate citation is:
+
+João A. Duro, Yiming Yan, Ioannis Giagkiozis, Stefanos Giagkiozis, Shaul Salomon,
+Daniel C. Oara, Ambuj K. Sriwastava, Jacqui Morison, Claire M. Freeman, Robert J.
+Lygoe, Robin C. Purshouse, and Peter J. Fleming. 2021. Liger: A cross-platform
+open-source integrated optimization and decision-making environment. Applied
+Soft Computing 98 (2021), 106851. https://doi.org/10.1016/j.asoc.2020.106851
+

--- a/dev/WindowsBuild/LigerSetupBuilder.iss
+++ b/dev/WindowsBuild/LigerSetupBuilder.iss
@@ -22,7 +22,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={pf}\{#MyAppName}
+DefaultDirName={commonpf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 LicenseFile={#ProjectDir}\LICENSE
 OutputDir={#BuildDir}
@@ -69,48 +69,50 @@ Root: HKCR; Subkey: "LigerWorkflowFile\DefaultIcon"; ValueType: string; ValueNam
 Root: HKCR; Subkey: "LigerWorkflowFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\bin\{#MyAppExeName}"" ""%1"""
 
 [Code]
-
 const 
   ModPathName = 'modifypath';
   ModPathType = 'user';
 
 function ModPathDir(): TArrayOfString;
 var 
-  DMatlabPath: TArrayOfString;
-  I: Integer;  
-  MFound: Boolean;
-  CMPath: String;
+  MatlabRootFolder: String;
+  MatlabInstalled: Boolean;
+  psub1, psub2, psub3, Path1, Path2, Path3: String;
 begin
-  
-  setArrayLength(DMatlabPath, 10);
-  I := 9;
-  MFound := false
-  DMatlabPath[0] := ExpandConstant('C:\Program Files\MATLAB\R2013a\bin\win64');
-  DMatlabPath[1] := ExpandConstant('C:\Program Files\MATLAB\R2013b\bin\win64');
-  DMatlabPath[2] := ExpandConstant('C:\Program Files\MATLAB\R2014a\bin\win64');
-  DMatlabPath[3] := ExpandConstant('C:\Program Files\MATLAB\R2014b\bin\win64');
-  DMatlabPath[4] := ExpandConstant('C:\Program Files\MATLAB\R2015a\bin\win64');
-  DMatlabPath[5] := ExpandConstant('C:\Program Files\MATLAB\R2015b\bin\win64');
-  DMatlabPath[6] := ExpandConstant('C:\Program Files\MATLAB\R2016a\bin\win64');
-  DMatlabPath[7] := ExpandConstant('C:\Program Files\MATLAB\R2016b\bin\win64');
-  DMatlabPath[8] := ExpandConstant('C:\Program Files\MATLAB\R2017a\bin\win64');
-  DMatlabPath[9] := ExpandConstant('C:\Program Files\MATLAB\R2017b\bin\win64');
-
-  while (MFound=FALSE) and (I>=0) do
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.1', 'MATLABROOT', MatlabRootFolder); // 2013a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.2', 'MATLABROOT', MatlabRootFolder); // 2013b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.3', 'MATLABROOT', MatlabRootFolder); // 2014a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.4', 'MATLABROOT', MatlabRootFolder); // 2014b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.5', 'MATLABROOT', MatlabRootFolder); // 2015a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\8.6', 'MATLABROOT', MatlabRootFolder); // 2015b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.0', 'MATLABROOT', MatlabRootFolder); // 2016a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.1', 'MATLABROOT', MatlabRootFolder); // 2016b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.2', 'MATLABROOT', MatlabRootFolder); // 2017a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.3', 'MATLABROOT', MatlabRootFolder); // 2017b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.4', 'MATLABROOT', MatlabRootFolder); // 2018a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.5', 'MATLABROOT', MatlabRootFolder); // 2018b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.6', 'MATLABROOT', MatlabRootFolder); // 2019a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.7', 'MATLABROOT', MatlabRootFolder); // 2019b
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.8', 'MATLABROOT', MatlabRootFolder); // 2020a
+  MatlabInstalled := RegQueryStringValue(HKLM, 'SOFTWARE\MathWorks\MATLAB\9.9', 'MATLABROOT', MatlabRootFolder); // 2020b
+  if MatlabInstalled then
   begin
-    CMPath := DMatlabPath[I];
-    MFound := DirExists(CMPath);
-    I := I-1;  
-  end;
   
-  if (MFound=true) then
-    begin
-      setArrayLength(Result, 1);
-      Result[0] := ExpandConstant(CMPath);
-    end
-  else
-    MsgBox('MATLAB Not found.', mbInformation, MB_OK);
+    // MsgBox('Found MATLAB Installation in ' + MatlabRootFolder, mbInformation, MB_OK);
 
+    psub1 := '\extern\bin\win64';
+	psub2 := '\runtime\win64';
+	psub3 := '\bin';
+
+	Path1 := MatlabRootFolder + psub1;
+	Path2 := MatlabRootFolder + psub2;
+	Path3 := MatlabRootFolder + psub3;
+
+    setArrayLength(Result, 3);
+	Result[0] := ExpandConstant(Path1);
+	Result[1] := ExpandConstant(Path2);
+	Result[2] := ExpandConstant(Path3);
+  end
 end;
 #include "modpath.iss"
 
@@ -124,9 +126,9 @@ type
   INSTALLSTATE = Longint;
 const
   INSTALLSTATE_DEFAULT = 5;      // The product is installed for the current user.
-  // Visual C++ 2015 Redistributable 14.0.23026
-  VC_2015_REDIST_X64_MIN = '{A1C31BA5-5438-3A07-9EEE-A5FB2D0FDE36}';
-  VC_2015_REDIST_X64_ADD = '{B0B194F8-E0CE-33FE-AA11-636428A4B73D}';
+  // Visual C++ 2019 Redistributable 14.25.28508
+  VC_2019_REDIST_X64_MIN = '{EEA66967-97E2-4561-A999-5C22E3CDE428}';
+  VC_2019_REDIST_X64_ADD = '{7D0B74C2-C3F8-4AF1-940F-CD79AB4B2DCE}';
 
 function MsiQueryProductState(szProduct: string): INSTALLSTATE; 
   external 'MsiQueryProductState{#AW}@msi.dll stdcall';
@@ -143,6 +145,6 @@ begin
   // this statement, the following won't install your VC redist only when
   // the Visual C++ 2010 Redist (x86) and Visual C++ 2010 SP1 Redist(x86)
   // are installed for the current user
-  Result := not (VCVersionInstalled(VC_2015_REDIST_X64_MIN) and 
-    VCVersionInstalled(VC_2015_REDIST_X64_ADD));
+  Result := not (VCVersionInstalled(VC_2019_REDIST_X64_MIN) and 
+    VCVersionInstalled(VC_2019_REDIST_X64_ADD));
 end;

--- a/dev/WindowsBuild/buildLigerReleaseForInstaller.bat
+++ b/dev/WindowsBuild/buildLigerReleaseForInstaller.bat
@@ -61,8 +61,8 @@ windeployqt.exe --compiler-runtime --release --no-translations ^
 -xml -concurrent -webenginecore -webengine -webenginewidgets -qthelp ^
 -sql -printsupport "%BUILDDIR%\bin\liger.exe"
 
-xcopy "%QTPATH%\Qt5QuickWidgets.dll" "%BUILDDIR%\bin\"
-xcopy "%PYTHON_DLL%" "%BUILDDIR%\bin\"
+xcopy "%QTPATH%\Qt5QuickWidgets.dll" "%BUILDDIR%\bin\" /c /h /y
+xcopy "%PYTHON_DLL%" "%BUILDDIR%\bin\" /c /h /y
 
 "%INNO_SETUP_DIR%\iscc" "%LIGERSRC%\dev\WindowsBuild\LigerSetupBuilder.iss" ^
 /DProjectDir="%LIGERSRC%" ^

--- a/dev/WindowsBuild/modpath.iss
+++ b/dev/WindowsBuild/modpath.iss
@@ -170,7 +170,7 @@ var
 begin
 	taskname := ModPathName;
 	if CurStep = ssPostInstall then
-		if IsTaskSelected(taskname) then
+		if WizardIsTaskSelected(taskname) then
 			ModPath();
 end;
 
@@ -211,7 +211,7 @@ var
 	taskname:	String;
 begin
 	taskname := ModPathName;
-	if IsTaskSelected(taskname) and not UsingWinNT() then begin
+	if WizardIsTaskSelected(taskname) and not UsingWinNT() then begin
 		Result := True;
 	end else begin
 		Result := False;


### PR DESCRIPTION
# Fix to Windows installer: 
* Adds three paths to the PATH environmental variable that are needed for Matlab
* Checks if Matlab is installed by reading the registry

# Update project readme file
* Update info on how to build from source
* Added License info