### PR TITLE
Workflow run time estimation

### DIFF
--- a/src/plugins/designer/iengine/icountinglabel.cpp
+++ b/src/plugins/designer/iengine/icountinglabel.cpp
@@ -44,6 +44,20 @@ void ICountingLabel::updateCount(int count)
 
     QString content;
     switch(m_labelFormat) {
+    case LABEL_FORMAT::TimeFormat:
+    {
+        long milli = count;
+        long hr = milli / 3600000;
+        milli = milli - 3600000 * hr;
+        long min = milli / 60000;
+        milli = milli - 60000 * min;
+        long sec = milli / 1000;
+        milli = milli - 1000 * sec;
+
+        content = QString::number(hr) + "h:" + QString::number(min) + "m:" +
+                  QString::number(sec)+ "s";
+        break;
+    }
     case LABEL_FORMAT::CountVsMax:
         content = QString::number(count) + "/" + QString::number(m_maxCount);
         break;

--- a/src/plugins/designer/iengine/icountinglabel.h
+++ b/src/plugins/designer/iengine/icountinglabel.h
@@ -24,7 +24,8 @@ namespace Designer {
 enum LABEL_FORMAT {
     CountOnly  = 0,
     CountVsMax = 1,
-    Percentage = 2
+    Percentage = 2,
+    TimeFormat = 3
 };
 
 class ICountingLabel : public QLabel

--- a/src/plugins/designer/iengine/iengine.h
+++ b/src/plugins/designer/iengine/iengine.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QList>
 #include <QObject>
+#include <QTimer>
 
 namespace Designer {
 
@@ -94,6 +95,7 @@ signals:
     /// Iteration and budget signals
     void signalIterationCounter(int iter);
     void signalBudgetCounter(int budget);
+    void signalTimeCounter(int time);
 
     /// Logging signals
     void signalPopulationsLog(const QJsonObject& jobj);
@@ -118,6 +120,8 @@ signals:
 private slots:
     void receivedIterationCount(int iter);
     void receivedBudgetCount(int budget);
+    void receivedTimeCount(int time);
+    void updateTimer();
 
 ///\todo Move all protected data to be private
 protected:
@@ -137,21 +141,30 @@ protected:
     QFuture<void> m_result;
     QFutureInterface<void>* m_iterationProgressInterface;
     QFutureInterface<void>* m_budgetProgressInterface;
+    QFutureInterface<void>* m_timeProgressInterface;
     QFutureWatcher<void>    m_iterationProgressWatcher;
     QFutureWatcher<void>    m_budgetProgressWatcher;
+    QFutureWatcher<void>    m_timeProgressWatcher;
     Core::FutureProgress*   m_iterationFutureProgress;
     Core::FutureProgress*   m_budgetFutureProgress;
+    Core::FutureProgress*   m_timeFutureProgress;
     volatile EngineStatus   m_engineStatus;
     int m_maxIteration;
     int m_budget;
     int m_currentIteration;
     int m_usedBudget;
 
+    int m_maxTime;
+    int m_remainingTime;
+    int m_timeSinceLastEstimate;
+
 private:
     void updateProcessNodeStatus(ProcessState state);
     void resetLogFlags();
 
     bool masterNodesPresent();
+
+    void resetTimer();
 
     QList<ILogManager*> m_logManagers;
     // Disable copying of an engine.
@@ -160,6 +173,8 @@ private:
 
     bool m_masterStartNodePresent;
     bool m_masterEndNodePresent;
+
+    QTimer* m_timer;
 };
 
 } // namespace Designer

--- a/src/plugins/designer/iengine/iprocessnode.h
+++ b/src/plugins/designer/iengine/iprocessnode.h
@@ -106,6 +106,8 @@ public:
     qint64 budget() const { return m_budget; }
     void setBudget(qint64 budget) { m_budget = budget; }
 
+    virtual bool isEstimateTime() const {return false;}
+
     /// Auto Pause
     /// \todo move to IEndNode
     virtual bool isPauseByIteration() const {return false;}

--- a/src/plugins/qtigon/dialogs/endnodedialog.cpp
+++ b/src/plugins/qtigon/dialogs/endnodedialog.cpp
@@ -113,6 +113,11 @@ bool EndNodeDialog::isUseIteration() const
     return ui->iterCheckBox->isChecked();
 }
 
+bool EndNodeDialog::isEstimateTime() const
+{
+    return ui->estimateTime->isChecked();
+}
+
 bool EndNodeDialog::isPauseByIteration() const
 {
     return ui->iterPauseCheckBox->isChecked();
@@ -191,6 +196,11 @@ void EndNodeDialog::setUseBugdget(bool b)
 void EndNodeDialog::setUseIter(bool b)
 {
     ui->iterCheckBox->setChecked(b);
+}
+
+void EndNodeDialog::setEstimateTime(bool b)
+{
+    ui->estimateTime->setChecked(b);
 }
 
 QString EndNodeDialog::iterPausePoints() const

--- a/src/plugins/qtigon/dialogs/endnodedialog.h
+++ b/src/plugins/qtigon/dialogs/endnodedialog.h
@@ -38,8 +38,10 @@ public:
     void   setBudget(qint64 budget);
     bool   isUseBuget() const;
     bool   isUseIteration() const;
+    bool   isEstimateTime() const;
     void   setUseBugdget(bool b=true);
     void   setUseIter(bool b=true);
+    void   setEstimateTime(bool b=false);
     bool   isPauseByIteration() const;
     bool   isPauseByBudget() const;
     void   setPauseByIteration(bool b=true);

--- a/src/plugins/qtigon/dialogs/endnodedialog.ui
+++ b/src/plugins/qtigon/dialogs/endnodedialog.ui
@@ -33,7 +33,7 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -58,7 +58,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="terminationTab">
       <attribute name="title">
@@ -113,6 +113,20 @@
          </item>
         </layout>
        </item>
+       <item row="3" column="0" rowspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="estimateTime">
+           <property name="text">
+            <string>Estimate time it takes to complete the optimization run</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
@@ -161,7 +175,7 @@
          </item>
         </layout>
        </item>
-       <item row="2" column="0">
+       <item row="6" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/plugins/qtigon/masterendnode.cpp
+++ b/src/plugins/qtigon/masterendnode.cpp
@@ -35,6 +35,7 @@ MasterEndNode::MasterEndNode()
     : m_dialog(new EndNodeDialog())
     , m_useIter(false)
     , m_useBudget(false)
+    , m_estimateTime(false)
     , m_pauseByIter(false)
     , m_pauseByBudget(false)
 {
@@ -113,6 +114,7 @@ void MasterEndNode::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
         m_dialog->setBudget(op->budget());
         m_dialog->setUseBugdget(isUseBudget());
         m_dialog->setUseIter(isUseIteration());
+        m_dialog->setEstimateTime(isEstimateTime());
         m_dialog->setPauseByIteration(isPauseByIteration());
         m_dialog->setPauseByBudget(isPauseByBudget());
         m_dialog->show();
@@ -282,6 +284,16 @@ void MasterEndNode::setUseIteration(bool useIter)
     m_useIter = useIter;
 }
 
+void MasterEndNode::setEstimateTime(bool estimateTime)
+{
+    m_estimateTime = estimateTime;
+}
+
+bool MasterEndNode::isEstimateTime() const
+{
+    return m_estimateTime;
+}
+
 void MasterEndNode::acceptChangesSlot()
 {
     ITermination* op = static_cast<ITermination*>(data());
@@ -302,6 +314,8 @@ void MasterEndNode::acceptChangesSlot()
     } else {
         op->resetBudget();
     }
+
+    setEstimateTime(m_dialog->isEstimateTime());
 
     setPauseByIteration(m_dialog->isPauseByIteration());
     setPauseByBudget(m_dialog->isPauseByBudget());

--- a/src/plugins/qtigon/masterendnode.h
+++ b/src/plugins/qtigon/masterendnode.h
@@ -33,6 +33,7 @@ class QTIGON_EXPORT MasterEndNode : public Designer::IProcessNode
 
     Q_PROPERTY(bool isUseBudget READ isUseBudget WRITE setUseBudget)
     Q_PROPERTY(bool isUseIteration READ isUseIteration WRITE setUseIteration)
+    Q_PROPERTY(bool isEstimateTime READ isEstimateTime WRITE setEstimateTime)
 
     Q_PROPERTY(QString iterPausePoints READ iterPausePoints WRITE setIterPausePoints)
     Q_PROPERTY(QString budgetPausePoints READ budgetPausePoints WRITE setBudgetPausePoints)
@@ -59,6 +60,10 @@ public:
 
     bool isUseBudget() const;
     void setUseBudget(bool isUseBudget);
+
+    /// Estimate time
+    bool isEstimateTime() const;
+    void setEstimateTime(bool estimateTime);
 
     /// Auto Pause \note only available through Liger GUI
     bool isPauseByIteration() const;
@@ -105,6 +110,7 @@ private:
     EndNodeDialog* m_dialog;
     bool           m_useIter;
     bool           m_useBudget;
+    bool           m_estimateTime;
     bool           m_pauseByIter;
     bool           m_pauseByBudget;
     bool           m_logPopulation;


### PR DESCRIPTION
# Estimation procedure
The procedure to estimate the time it takes to complete the optimization run is as follows.
1. The time it takes (in miliseconds) to complete each iteration is measured.
2. The measured time can vary (sometimes widely) between consecutive iterations. To generate a smooth estimate an exponential smoothing function is used, as given by
```math
s_0 = t_0
```
```math
s_k = \alpha t_k + (1 - \alpha) s_{k-1},~ k>0
```
The best results obtained so far are with $`\alpha=0.2`$. Ideally this parameters should be estimated from the data. 

3. The estimate is shown in a progress bar while Liger GUI is running, and the format is hh:mm:ss.

# Quick notes
- The above estimation procedure is implemented in the Qt plugin responsible for running the Tigon engine, and thus it is not part of Tigon. We might want to move this functionality into the Tigon library in the future. 
- A checkbox has been added to the `MasterEndNode` that can be used to disable this feature when desirable.

# Show number in time format
Extended the functionality of `ICountingLabel` to convert and display a number (in milliseconds) in the format hh:mm:ss. The conversion procedure is as follows. First let the number in milliseconds to be converted be given by $`ms`$, and the hours, minutes and seconds are given respectively by:
```math
hh = ms / 3600000
```
```math
mm = (ms - 3600000 hh) / 60000
```
```math
ss = ((ms - 3600000 hh) - 60000 mm) / 1000
```

# Code
1. `IEngine`: Here we define the progress bar and how it will be created and updated.
- Declaration of time progress interface, time progress watcher and time future progress, similar to the existing ones in `IEngine` class for iteration and budget. 
- Initialization of the progress interface, watcher, future and assigned a `ICountingLabel` to time future progress in `IEngine::start()`.
- Similar to other progress bars, defined the desired behaviour when engine pauses, resumes and exits.
- Defined a signal, `signalTimeCounter` to allow QTigonEngine to emit the current estimated time, and a slot `receivedTimeCount` to handle this piece of information to update the current estimate in `IEngine`.
- To ensure that the estimated number is not updated (shown in the GUI) each time `QTigonEngine` sends a signal with a new estimate (which could be every millisecond), a `QTimer` object simulates a 1s signal, and this signal is connected to the slot `updateTimer()` which is responsible for updating the progress bar label.

2. `QTigonEngine`.
- Inside `QTigonEngine::engine_loop()`, there is the procedure for determining the time estimate as described above. Once a new estimate is determined, the signal `signalTimeCounter` is used to update the new estimate in `IEngine`.

3. `IProcessNode`, `MasterEndNode` and `EndNodeDialog`.
- Implemented and exposed proper functions to allow the user to enable or disable the time progress bar.